### PR TITLE
feat: improve Docker Skill

### DIFF
--- a/plugins/devops-skills/skills/docker-local-dev/SKILL.md
+++ b/plugins/devops-skills/skills/docker-local-dev/SKILL.md
@@ -578,6 +578,10 @@ docker compose logs -f
 | Redis | localhost:6379 | - |
 | Mail UI | http://localhost:8025 | - |
 
+## Container Networking (Important)
+
+When the app runs inside Docker, `localhost` points to the app container. To connect to other services, use the Docker Compose service name (for example `db`, `redis`, `mailpit`) instead of `localhost`.
+
 ## Stack-Specific Commands
 
 ### Laravel

--- a/plugins/devops-skills/skills/docker-local-dev/assets/templates/dockerfile/php-drupal.dockerfile
+++ b/plugins/devops-skills/skills/docker-local-dev/assets/templates/dockerfile/php-drupal.dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     libzip-dev \
     libicu-dev \
     libxml2-dev \
+    libmagickwand-dev \
     mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
@@ -28,6 +29,9 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
         intl \
         xml \
         opcache
+
+# Install ImageMagick
+RUN pecl install imagick && docker-php-ext-enable imagick
 
 # Install Redis extension
 RUN pecl install redis && docker-php-ext-enable redis

--- a/plugins/devops-skills/skills/docker-local-dev/assets/templates/dockerfile/php-joomla.dockerfile
+++ b/plugins/devops-skills/skills/docker-local-dev/assets/templates/dockerfile/php-joomla.dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     libicu-dev \
     libxml2-dev \
     libldap2-dev \
+    libmagickwand-dev \
     mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
@@ -29,6 +30,9 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
         xml \
         ldap \
         opcache
+
+# Install ImageMagick
+RUN pecl install imagick && docker-php-ext-enable imagick
 
 # Install Redis extension
 RUN pecl install redis && docker-php-ext-enable redis

--- a/plugins/devops-skills/skills/docker-local-dev/assets/templates/dockerfile/php-laravel.dockerfile
+++ b/plugins/devops-skills/skills/docker-local-dev/assets/templates/dockerfile/php-laravel.dockerfile
@@ -12,10 +12,12 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     libjpeg-dev \
     libfreetype6-dev \
+    libmagickwand-dev \
     libonig-dev \
     libxml2-dev \
     libzip-dev \
     libicu-dev \
+    mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure and install PHP extensions
@@ -31,6 +33,9 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
         intl \
         xml \
         opcache
+
+# Install ImageMagick
+RUN pecl install imagick && docker-php-ext-enable imagick
 
 # Install Redis extension
 RUN pecl install redis && docker-php-ext-enable redis

--- a/plugins/devops-skills/skills/docker-local-dev/assets/templates/docs/USAGE.md.template
+++ b/plugins/devops-skills/skills/docker-local-dev/assets/templates/docs/USAGE.md.template
@@ -37,6 +37,24 @@ docker compose restart app
 | Redis | localhost:{{REDIS_PORT}} | - |
 | Mail UI | http://localhost:{{MAIL_UI_PORT}} | - |
 
+## Container Networking (Important)
+
+When your app runs inside Docker, `localhost` points to the **app container**, not your database container.
+Use the **service name** from `docker-compose.yml` instead.
+
+Common defaults:
+- Database host from app container: `db`
+- Redis host from app container: `redis`
+- Mail host from app container: `mailpit`
+
+Laravel example (`.env` inside the container):
+```
+DB_HOST=db
+DB_PORT=3306
+REDIS_HOST=redis
+MAIL_HOST=mailpit
+```
+
 ## Stack-Specific Commands
 
 ### {{FRAMEWORK}} Commands

--- a/skills/docker-local-dev/SKILL.md
+++ b/skills/docker-local-dev/SKILL.md
@@ -578,6 +578,10 @@ docker compose logs -f
 | Redis | localhost:6379 | - |
 | Mail UI | http://localhost:8025 | - |
 
+## Container Networking (Important)
+
+When the app runs inside Docker, `localhost` points to the app container. To connect to other services, use the Docker Compose service name (for example `db`, `redis`, `mailpit`) instead of `localhost`.
+
 ## Stack-Specific Commands
 
 ### Laravel

--- a/skills/docker-local-dev/assets/templates/dockerfile/php-drupal.dockerfile
+++ b/skills/docker-local-dev/assets/templates/dockerfile/php-drupal.dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     libzip-dev \
     libicu-dev \
     libxml2-dev \
+    libmagickwand-dev \
     mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
@@ -28,6 +29,9 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
         intl \
         xml \
         opcache
+
+# Install ImageMagick
+RUN pecl install imagick && docker-php-ext-enable imagick
 
 # Install Redis extension
 RUN pecl install redis && docker-php-ext-enable redis

--- a/skills/docker-local-dev/assets/templates/dockerfile/php-joomla.dockerfile
+++ b/skills/docker-local-dev/assets/templates/dockerfile/php-joomla.dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     libicu-dev \
     libxml2-dev \
     libldap2-dev \
+    libmagickwand-dev \
     mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
@@ -29,6 +30,9 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
         xml \
         ldap \
         opcache
+
+# Install ImageMagick
+RUN pecl install imagick && docker-php-ext-enable imagick
 
 # Install Redis extension
 RUN pecl install redis && docker-php-ext-enable redis

--- a/skills/docker-local-dev/assets/templates/dockerfile/php-laravel.dockerfile
+++ b/skills/docker-local-dev/assets/templates/dockerfile/php-laravel.dockerfile
@@ -12,10 +12,12 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     libjpeg-dev \
     libfreetype6-dev \
+    libmagickwand-dev \
     libonig-dev \
     libxml2-dev \
     libzip-dev \
     libicu-dev \
+    mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure and install PHP extensions
@@ -31,6 +33,9 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
         intl \
         xml \
         opcache
+
+# Install ImageMagick
+RUN pecl install imagick && docker-php-ext-enable imagick
 
 # Install Redis extension
 RUN pecl install redis && docker-php-ext-enable redis

--- a/skills/docker-local-dev/assets/templates/docs/USAGE.md.template
+++ b/skills/docker-local-dev/assets/templates/docs/USAGE.md.template
@@ -37,6 +37,24 @@ docker compose restart app
 | Redis | localhost:{{REDIS_PORT}} | - |
 | Mail UI | http://localhost:{{MAIL_UI_PORT}} | - |
 
+## Container Networking (Important)
+
+When your app runs inside Docker, `localhost` points to the **app container**, not your database container.
+Use the **service name** from `docker-compose.yml` instead.
+
+Common defaults:
+- Database host from app container: `db`
+- Redis host from app container: `redis`
+- Mail host from app container: `mailpit`
+
+Laravel example (`.env` inside the container):
+```
+DB_HOST=db
+DB_PORT=3306
+REDIS_HOST=redis
+MAIL_HOST=mailpit
+```
+
 ## Stack-Specific Commands
 
 ### {{FRAMEWORK}} Commands


### PR DESCRIPTION
This pull request improves the Docker local development experience by adding support for the ImageMagick extension in PHP containers and clarifying container networking practices in the documentation. The key changes are grouped below:

**PHP Dockerfile Enhancements:**

* Added installation of the `libmagickwand-dev` package and the `imagick` PHP extension (via PECL) to the `php-laravel.dockerfile`, `php-drupal.dockerfile`, and `php-joomla.dockerfile` templates to enable ImageMagick support in all PHP-based stacks. [[1]](diffhunk://#diff-265c22031cb8577fd341af2066412327b07a3753628f0efcb89ac09da3b6d350R15-R20) [[2]](diffhunk://#diff-265c22031cb8577fd341af2066412327b07a3753628f0efcb89ac09da3b6d350R37-R39) [[3]](diffhunk://#diff-4fa3307a90bebc1ac9ebb1ee5b19c10c3d48d1f38e6e68d7f0f0e8cbe4fa78f2R19) [[4]](diffhunk://#diff-4fa3307a90bebc1ac9ebb1ee5b19c10c3d48d1f38e6e68d7f0f0e8cbe4fa78f2R33-R35) [[5]](diffhunk://#diff-df458abce609bd236db06e2277a026ae3be84666f7a736c88c890cfc8e848298R18) [[6]](diffhunk://#diff-df458abce609bd236db06e2277a026ae3be84666f7a736c88c890cfc8e848298R34-R36)

**Documentation Improvements:**

* Added a new "Container Networking (Important)" section to both `SKILL.md` and `USAGE.md.template` files, explaining that `localhost` refers to the app container itself and instructing users to use Docker Compose service names (like `db`, `redis`, `mailpit`) for inter-container communication. Also included specific examples for Laravel environment configuration. [[1]](diffhunk://#diff-b84ee41759915a88deafdaf1bf0515717c8bf16abef0ce7d1710ee33cdb70c5eR581-R584) [[2]](diffhunk://#diff-27e468ad981683c3018822520d99943c1452806a183f56f09641e7c308a164f6R40-R57)

These updates help ensure PHP applications have better image processing capabilities out of the box and reduce confusion around service connectivity within Docker environments.