### PR TITLE
feat: add ask-questions-if-underspecified skill and some tweaks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,6 +36,15 @@
       "skills": [
         "./skills/docker-local-dev"
       ]
+    },
+    {
+      "name": "workflow-skills",
+      "description": "Skills for AI agent workflow and requirements clarification processes.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/ask-questions-if-underspecified"
+      ]
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,11 @@ Every skill must have a `SKILL.md` with YAML frontmatter:
 ---
 name: skill-name
 description: Brief description of what the skill does and when to use it.
+author: Your Name or Team (optional but recommended)
 ---
 ```
+
+When adding a new skill, always ask for the author name if not provided. The author field is displayed in the README skills table.
 
 ## Scanning and Updating Marketplace
 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,13 @@ You can also copy individual skill instructions directly into your AI agent's co
 ## Available Skills
 
 <!-- SKILLS_TABLE_START -->
-| Skill | Description |
-|-------|-------------|
-| [agents-md-generator](./skills/agents-md-generator) | Generate or update CLAUDE.md/AGENTS.md files for AI coding agents through auto-scanning project files combined with interactive Q&A. Supports multiple tech stacks, development environments, and preserves customizations when updating. |
-| [docker-local-dev](./skills/docker-local-dev) | Generate Docker Compose and Dockerfile configurations for local development through interactive Q&A. Supports PHP/Laravel, WordPress, Drupal, Joomla, Node.js, and Python stacks with Nginx, Supervisor/PM2, databases, Redis, and email testing. Always asks clarifying questions before generating configurations. |
-| [documentation-guidelines](./skills/documentation-guidelines) | Write or update backend feature documentation that follows a repo's DOCUMENTATION_GUIDELINES.md (or equivalent) across any project. Use when asked to create/update module docs, API contracts, or backend documentation that must include architecture, endpoints, payloads, Mermaid diagrams, and seeding instructions. |
-| [laravel-11-12-app-guidelines](./skills/laravel-11-12-app-guidelines) | Guidelines and workflow for working on Laravel 11 or Laravel 12 applications across common stacks (API-only or full-stack), including optional Docker Compose/Sail, Inertia + React, Livewire, Vue, Blade, Tailwind v4, Fortify, Wayfinder, PHPUnit, Pint, and Laravel Boost MCP tools. Use when implementing features, fixing bugs, or making UI/backend changes while following project-specific instructions (AGENTS.md, docs/). |
+| Skill | Author | Description |
+|-------|--------|-------------|
+| [agents-md-generator](./skills/agents-md-generator) | Community | Generate or update CLAUDE.md/AGENTS.md files for AI coding agents through auto-scanning project files combined with interactive Q&A. Supports multiple tech stacks, development environments, and preserves customizations when updating. |
+| [ask-questions-if-underspecified](./skills/ask-questions-if-underspecified) | Tibo (Codex Team) | Clarify requirements before implementing. Do not use automatically, only when invoked explicitly. |
+| [docker-local-dev](./skills/docker-local-dev) | Community | Generate Docker Compose and Dockerfile configurations for local development through interactive Q&A. Supports PHP/Laravel, WordPress, Drupal, Joomla, Node.js, and Python stacks with Nginx, Supervisor/PM2, databases, Redis, and email testing. Always asks clarifying questions before generating configurations. |
+| [documentation-guidelines](./skills/documentation-guidelines) | Community | Write or update backend feature documentation that follows a repo's DOCUMENTATION_GUIDELINES.md (or equivalent) across any project. Use when asked to create/update module docs, API contracts, or backend documentation that must include architecture, endpoints, payloads, Mermaid diagrams, and seeding instructions. |
+| [laravel-11-12-app-guidelines](./skills/laravel-11-12-app-guidelines) | Community | Guidelines and workflow for working on Laravel 11 or Laravel 12 applications across common stacks (API-only or full-stack), including optional Docker Compose/Sail, Inertia + React, Livewire, Vue, Blade, Tailwind v4, Fortify, Wayfinder, PHPUnit, Pint, and Laravel Boost MCP tools. Use when implementing features, fixing bugs, or making UI/backend changes while following project-specific instructions (AGENTS.md, docs/). |
 <!-- SKILLS_TABLE_END -->
 
 ## Plugin Groups

--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -21,6 +21,13 @@
       "skills": [
         "docker-local-dev"
       ]
+    },
+    {
+      "name": "workflow-skills",
+      "description": "Skills for AI agent workflow and requirements clarification processes.",
+      "skills": [
+        "ask-questions-if-underspecified"
+      ]
     }
   ]
 }

--- a/scripts/sync-marketplace.js
+++ b/scripts/sync-marketplace.js
@@ -137,7 +137,8 @@ function getSkills() {
     skills.push({
       folderName: skillName,
       name: frontmatter.name,
-      description: frontmatter.description
+      description: frontmatter.description,
+      author: frontmatter.author || null
     });
   }
 
@@ -216,9 +217,9 @@ function updateReadme(skills) {
   let content = fs.readFileSync(README_FILE, 'utf-8');
 
   // Build skills table
-  const tableHeader = '| Skill | Description |\n|-------|-------------|';
+  const tableHeader = '| Skill | Author | Description |\n|-------|--------|-------------|';
   const tableRows = skills.map(skill =>
-    `| [${skill.name}](./skills/${skill.folderName}) | ${skill.description} |`
+    `| [${skill.name}](./skills/${skill.folderName}) | ${skill.author || '—'} | ${skill.description} |`
   ).join('\n');
   const newTable = `<!-- SKILLS_TABLE_START -->\n${tableHeader}\n${tableRows}\n<!-- SKILLS_TABLE_END -->`;
 

--- a/skills/agents-md-generator/SKILL.md
+++ b/skills/agents-md-generator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: agents-md-generator
 description: Generate or update CLAUDE.md/AGENTS.md files for AI coding agents through auto-scanning project files combined with interactive Q&A. Supports multiple tech stacks, development environments, and preserves customizations when updating.
+author: Community
 ---
 
 # AGENTS.md / CLAUDE.md Generator

--- a/skills/ask-questions-if-underspecified/SKILL.md
+++ b/skills/ask-questions-if-underspecified/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: ask-questions-if-underspecified
+description: Clarify requirements before implementing. Do not use automatically, only when invoked explicitly.
+author: Tibo (Codex Team)
+---
+
+# Ask Questions If Underspecified
+
+## Goal
+
+Ask the minimum set of clarifying questions needed to avoid wrong work; do not start implementing until the must-have questions are answered (or the user explicitly approves proceeding with stated assumptions).
+
+## Workflow
+
+### 1) Decide whether the request is underspecified
+
+Treat a request as underspecified if after exploring how to perform the work, some or all of the following are not clear:
+- Define the objective (what should change vs stay the same)
+- Define "done" (acceptance criteria, examples, edge cases)
+- Define scope (which files/components/users are in/out)
+- Define constraints (compatibility, performance, style, deps, time)
+- Identify environment (language/runtime versions, OS, build/test runner)
+- Clarify safety/reversibility (data migration, rollout/rollback, risk)
+
+If multiple plausible interpretations exist, assume it is underspecified.
+
+### 2) Ask must-have questions first (keep it small)
+
+Ask 1-5 questions in the first pass. Prefer questions that eliminate whole branches of work.
+
+Make questions easy to answer:
+- Optimize for scannability (short, numbered questions; avoid paragraphs)
+- Offer multiple-choice options when possible
+- Suggest reasonable defaults when appropriate (mark them clearly as the default/recommended choice; bold the recommended choice in the list, or if you present options in a code block, put a bold "Recommended" line immediately above the block and also tag defaults inside the block)
+- Include a fast-path response (e.g., reply `defaults` to accept all recommended/default choices)
+- Include a low-friction "not sure" option when helpful (e.g., "Not sure - use default")
+- Separate "Need to know" from "Nice to know" if that reduces friction
+- Structure options so the user can respond with compact decisions (e.g., `1b 2a 3c`); restate the chosen options in plain language to confirm
+
+### 3) Pause before acting
+
+Until must-have answers arrive:
+- Do not run commands, edit files, or produce a detailed plan that depends on unknowns
+- Do perform a clearly labeled, low-risk discovery step only if it does not commit you to a direction (e.g., inspect repo structure, read relevant config files)
+
+If the user explicitly asks you to proceed without answers:
+- State your assumptions as a short numbered list
+- Ask for confirmation; proceed only after they confirm or correct them
+
+### 4) Confirm interpretation, then proceed
+
+Once you have answers, restate the requirements in 1-3 sentences (including key constraints and what success looks like), then start work.
+
+## Question templates
+
+- "Before I start, I need: (1) ..., (2) ..., (3) .... If you don't care about (2), I will assume ...."
+- "Which of these should it be? A) ... B) ... C) ... (pick one)"
+- "What would you consider 'done'? For example: ..."
+- "Any constraints I must follow (versions, performance, style, deps)? If none, I will target the existing project defaults."
+- Use numbered questions with lettered options and a clear reply format
+
+```text
+1) Scope?
+a) Minimal change (default)
+b) Refactor while touching the area
+c) Not sure - use default
+2) Compatibility target?
+a) Current project defaults (default)
+b) Also support older versions: <specify>
+c) Not sure - use default
+
+Reply with: defaults (or 1a 2a)
+```
+
+## Anti-patterns
+
+- Don't ask questions you can answer with a quick, low-risk discovery read (e.g., configs, existing patterns, docs).
+- Don't ask open-ended questions if a tight multiple-choice or yes/no would eliminate ambiguity faster.

--- a/skills/docker-local-dev/SKILL.md
+++ b/skills/docker-local-dev/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: docker-local-dev
 description: Generate Docker Compose and Dockerfile configurations for local development through interactive Q&A. Supports PHP/Laravel, WordPress, Drupal, Joomla, Node.js, and Python stacks with Nginx, Supervisor/PM2, databases, Redis, and email testing. Always asks clarifying questions before generating configurations.
+author: Community
 ---
 
 # Docker Local Development Environment Generator

--- a/skills/documentation-guidelines/SKILL.md
+++ b/skills/documentation-guidelines/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: documentation-guidelines
 description: Write or update backend feature documentation that follows a repo's DOCUMENTATION_GUIDELINES.md (or equivalent) across any project. Use when asked to create/update module docs, API contracts, or backend documentation that must include architecture, endpoints, payloads, Mermaid diagrams, and seeding instructions.
+author: Community
 ---
 
 # Documentation Guidelines

--- a/skills/laravel-11-12-app-guidelines/SKILL.md
+++ b/skills/laravel-11-12-app-guidelines/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: laravel-11-12-app-guidelines
 description: Guidelines and workflow for working on Laravel 11 or Laravel 12 applications across common stacks (API-only or full-stack), including optional Docker Compose/Sail, Inertia + React, Livewire, Vue, Blade, Tailwind v4, Fortify, Wayfinder, PHPUnit, Pint, and Laravel Boost MCP tools. Use when implementing features, fixing bugs, or making UI/backend changes while following project-specific instructions (AGENTS.md, docs/).
+author: Community
 ---
 
 # Laravel 11/12 App Guidelines


### PR DESCRIPTION
feat: add author metadata to skills and expand marketplace with workflow-skills

- Added `author` field to all skills for better attribution and inclusion in the README table.
- Updated `sync-marketplace.js` to handle `author` metadata and expand README with an "Author" column in the skills table.
- Introduced the `workflow-skills` plugin with a new `ask-questions-if-underspecified` skill.
- Updated `marketplace.json` and `plugin-groups.json` to include `workflow-skills`.