### PR TITLE
feat: add ui-mockup-visualizer skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,6 +64,15 @@
       "skills": [
         "./skills/office-web-ui-system"
       ]
+    },
+    {
+      "name": "ui-design-skills",
+      "description": "Skills for visualizing UI ideas as reviewable mockups and wireframes across web, mobile, and desktop apps.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/ui-mockup-visualizer"
+      ]
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,13 @@ mkdir -p skills/your-skill-name
 
 ### Step 2: Create SKILL.md
 
-Create a `SKILL.md` file with the required YAML frontmatter:
+Create a `SKILL.md` file with YAML frontmatter. `name` and `description` are required. `author` is strongly recommended:
 
 ```markdown
 ---
 name: your-skill-name
 description: Brief description of what the skill does and when to use it.
+author: Your Name or Team
 ---
 
 # Your Skill Name
@@ -201,6 +202,7 @@ git push origin main
 |-------|-------------|
 | `name` | Skill identifier (should match folder name, kebab-case) |
 | `description` | Clear description of what the skill does and when to use it |
+| `author` | Recommended display name for the README skills table |
 
 ### Example
 
@@ -208,6 +210,7 @@ git push origin main
 ---
 name: api-documentation
 description: Generate comprehensive API documentation from code. Use when documenting REST APIs, GraphQL endpoints, or RPC services.
+author: Official
 ---
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Skills are self-contained instruction sets that teach AI agents specific workflo
 
 # Install office web UI skill
 /plugin install office-web-ui-skills@awesome-ai-agent-skills
+
+# Install UI mockup and wireframe skill
+/plugin install ui-design-skills@awesome-ai-agent-skills
 ```
 
 **Updating the marketplace**
@@ -69,6 +72,7 @@ You can also copy individual skill instructions directly into your AI agent's co
 | [find-scene](./skills/find-scene) | — | Search movie and TV show scenes by dialog, time, or visual description. Download video clips, extract frames, find quotes, identify movies from quotes, and query IMDB data. Use when the user wants to find a specific scene, download a clip, search for a quote in a movie/show, extract a frame, or get movie information via the find-scene API. |
 | [laravel-11-12-app-guidelines](./skills/laravel-11-12-app-guidelines) | Official | Guidelines and workflow for working on Laravel 11 or Laravel 12 applications across common stacks (API-only or full-stack), including optional Docker Compose/Sail, Inertia + React, Livewire, Vue, Blade, Tailwind v4, Fortify, Wayfinder, PHPUnit, Pint, and Laravel Boost MCP tools. Use when implementing features, fixing bugs, or making UI/backend changes while following project-specific instructions (AGENTS.md, docs/). |
 | [office-web-ui-system](./skills/office-web-ui-system) | Official | Design and refactor polished office-style web app interfaces for admin, internal, and back-office products. Use when an AI agent needs to build or improve dashboards, stat cards, page heroes, filter/search bars, data tables, shells, side panels, semantic locator classes, or reusable page composition that stays portable across Vue, React, Laravel, and other web stacks with or without PrimeVue. |
+| [ui-mockup-visualizer](./skills/ui-mockup-visualizer) | Official | Create fixed-canvas HTML wireframes and visual mockups that help an AI agent verify and explain its understanding of UI/UX requests for websites, mobile apps, and desktop apps. Use when a user asks for UI ideas, visual confirmation, layout exploration, wireframes, HTML mockups, design critique, or says things like "show me the layout", "make a mockup", "wireframe this", "give me 3 UI options", "visualize what you mean", "show the screen idea", "show the sidebar idea", or "turn this into HTML so I can review it". This skill always proposes Option A, Option B, and Option C, marks one AI-recommended option, supports multi-select or "none", uses stable web/mobile/desktop templates, starts a local preview server, and can capture review screenshots into docs/awesome-ai-agent-skills/visuals/. |
 <!-- SKILLS_TABLE_END -->
 
 ## Plugin Groups
@@ -84,6 +88,7 @@ Plugins bundle related skills so you can install by domain. The source of truth 
 | [workflow-skills](./plugin-groups.json) | Skills for AI agent workflow and requirements clarification processes. | [ask-questions-if-underspecified](./skills/ask-questions-if-underspecified) |
 | [media-skills](./plugin-groups.json) | Skills for searching, downloading, and processing video and media content. | [find-scene](./skills/find-scene) |
 | [office-web-ui-skills](./plugin-groups.json) | Skills for designing and refactoring admin, internal, and back-office web interfaces. | [office-web-ui-system](./skills/office-web-ui-system) |
+| [ui-design-skills](./plugin-groups.json) | Skills for visualizing UI ideas as reviewable mockups and wireframes across web, mobile, and desktop apps. | [ui-mockup-visualizer](./skills/ui-mockup-visualizer) |
 <!-- PLUGINS_TABLE_END -->
 
 ## Contributing
@@ -97,6 +102,7 @@ We welcome contributions! Here's a quick start:
    ---
    name: your-skill-name
    description: What the skill does and when to use it.
+   author: Your Name or Team
    ---
    ```
 4. Add the skill to `plugin-groups.json` so it belongs to exactly one plugin.

--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -43,6 +43,13 @@
       "skills": [
         "office-web-ui-system"
       ]
+    },
+    {
+      "name": "ui-design-skills",
+      "description": "Skills for visualizing UI ideas as reviewable mockups and wireframes across web, mobile, and desktop apps.",
+      "skills": [
+        "ui-mockup-visualizer"
+      ]
     }
   ]
 }

--- a/skills/ui-mockup-visualizer/SKILL.md
+++ b/skills/ui-mockup-visualizer/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: ui-mockup-visualizer
+description: Create fixed-canvas HTML wireframes and visual mockups that help an AI agent verify and explain its understanding of UI/UX requests for websites, mobile apps, and desktop apps. Use when a user asks for UI ideas, visual confirmation, layout exploration, wireframes, HTML mockups, design critique, or says things like "show me the layout", "make a mockup", "wireframe this", "give me 3 UI options", "visualize what you mean", "show the screen idea", "show the sidebar idea", or "turn this into HTML so I can review it". This skill always proposes Option A, Option B, and Option C, marks one AI-recommended option, supports multi-select or "none", uses stable web/mobile/desktop templates, starts a local preview server, and can capture review screenshots into docs/awesome-ai-agent-skills/visuals/.
+author: Official
+---
+
+# UI Mockup Visualizer
+
+## Overview
+
+Use this skill to turn UI/UX discussion into concrete HTML mockups quickly, so the user can verify whether the agent is visualizing the right thing before implementation starts.
+
+Default to this skill whenever a user wants to see the layout the agent is describing, wants UI/UX ideas, wants visual comparison, or needs a fast wireframe for websites, mobile apps, or desktop apps. Skip it only when the user explicitly asks for text-only output.
+
+Read these references as needed:
+- `references/mockup-design-system.md`
+- `references/pattern-benchmarks.md`
+
+Strong trigger cues:
+- the user wants to "see" what the agent means before implementation
+- the user asks for several UI directions to compare
+- the user asks for a mockup, wireframe, layout sketch, or HTML preview
+- the user is discussing a specific surface such as sidebar, modal, dashboard block, form area, mobile screen, or desktop panel
+
+## Workflow
+
+### 1. Lock the problem scope
+
+Compress the request to the smallest visual surface that matters:
+- the exact region the user cares about
+- the platform: `web-desktop`, `mobile-app`, or `desktop-app`
+- the main job of the surface
+- the constraint that matters most: density, clarity, speed, hierarchy, approval flow, or discoverability
+
+Do not mock the entire product unless the whole-page structure is the question. Keep the mockup focused and use empty context blocks to show placement.
+
+### 2. Generate three options every time
+
+Always present:
+- `Option A`
+- `Option B`
+- `Option C`
+
+Rules:
+- make all three options plausible, not random
+- keep them meaningfully different in hierarchy or interaction model
+- mark exactly one option as `Recommended`
+- include one sentence telling the user why that option is the best fit
+- always allow the user to reply with one or more option letters or say that none of them fit
+
+Use this reply contract:
+
+```text
+What I think you want
+<1-2 concise sentences>
+
+Options
+- Option A: ...
+- Option B: ...
+- Option C: ...
+- Recommended: Option B because ...
+
+Reply with:
+- one option: "Option B"
+- many options: "Option A + C"
+- reject all: "None, I want ..."
+```
+
+### 3. Cite benchmarks without turning the task into research
+
+Use 1-3 benchmark references from major products when they genuinely clarify the pattern. Prefer stable, product-level references such as:
+- Notion for peek panels and contextual side surfaces
+- Slack for threaded sidebars and utility panels
+- GitHub or Shopify for dense admin information layout
+- Linear for compact issue/workspace structure
+- Apple Settings for clear mobile preference architecture
+
+Do not pretend these are exact copies. State the pattern, not the brand styling.
+
+If the user asks for the latest real-world examples, exact citations, or proof of current practice, browse official/public sources before making the claim.
+
+### 4. Build the mockup with the stable template
+
+Prefer the bundled template so the visual language stays consistent across sessions.
+
+Create the workspace under the current project:
+
+```bash
+python3 scripts/init_mockup_workspace.py \
+  /absolute/path/to/project/docs/awesome-ai-agent-skills/mockups/<slug> \
+  --title "Short mockup question" \
+  --platform web-desktop
+```
+
+The script creates a ready-to-edit static mockup package and picks the matching template variant:
+- `assets/mockup-template/` for `web-desktop`
+- `assets/mockup-template-mobile-app/` for `mobile-app`
+- `assets/mockup-template-desktop-app/` for `desktop-app`
+
+Prefer editing `mockup-data.js` only. Change `index.html`, `styles.css`, or `app.js` only when the default system cannot express the idea.
+
+### 5. Serve the mockup locally
+
+Start a local server from the mockup directory:
+
+```bash
+python3 scripts/start_mockup_server.py \
+  /absolute/path/to/project/docs/awesome-ai-agent-skills/mockups/<slug>
+```
+
+This prints a local URL and writes `.mockup-server.json` in the mockup folder. Share the URL with the user.
+
+Stop it when the user has approved the direction:
+
+```bash
+python3 scripts/stop_mockup_server.py \
+  /absolute/path/to/project/docs/awesome-ai-agent-skills/mockups/<slug>
+```
+
+### 6. Capture screenshots for verification memory
+
+Prefer Chrome DevTools MCP or Playwright MCP when available because they can capture exactly what the agent sees.
+
+Also keep the local fallback script available:
+
+```bash
+python3 scripts/capture_mockup.py \
+  --url http://127.0.0.1:4173 \
+  --output /absolute/path/to/project/docs/awesome-ai-agent-skills/visuals/<slug>-q1.jpg
+```
+
+Use numbered checkpoint images whenever the direction changes materially:
+- `.../visuals/<slug>-q1.jpg`
+- `.../visuals/<slug>-q2.jpg`
+- `.../visuals/<slug>-q3.jpg`
+
+If Chrome DevTools MCP or Playwright MCP is missing, explicitly recommend installing one of them for faster headless verification.
+
+### 7. Handoff after approval
+
+After the user approves one option or a merged direction:
+- stop the preview server unless the user still needs it
+- summarize the chosen structure
+- translate the mockup into implementation instructions with exact layout behavior, spacing logic, states, and component hierarchy
+- call out what remains intentionally undecided
+
+Do not jump into full production implementation guidance before the user confirms the visual direction.
+
+## Rules
+
+- Default to making a visual whenever the user wants UI/UX ideas or wants to verify the agent's understanding.
+- Keep the canvas fixed-size. Do not make the mockup responsive.
+- Use placeholder blocks, not final content, unless real content is necessary to explain hierarchy.
+- Focus the mockup on the requested surface. Surround it with muted context blocks only to explain position.
+- Keep output token-efficient by reusing the template and editing structured data instead of rewriting the whole page.
+- Use `Option A`, `Option B`, and `Option C` exactly so the user can refer to them quickly.
+- Mark one option as `Recommended` every time.
+- Let the user combine options or reject all three.
+- Cite large-product benchmarks as pattern references, not as license to clone branding.
+- Prefer the bundled template and scripts over inventing a new mockup runtime.
+- Save screenshots under `docs/awesome-ai-agent-skills/visuals/` whenever the discussion reaches a stable checkpoint.
+
+## Resources
+
+### scripts/
+
+- `scripts/init_mockup_workspace.py`: create a mockup workspace from the bundled template
+- `scripts/start_mockup_server.py`: start a local static server and record its state
+- `scripts/stop_mockup_server.py`: stop the recorded local server
+- `scripts/capture_mockup.py`: capture a mockup URL to an image with local Chrome/Chromium when available
+
+### references/
+- `references/mockup-design-system.md`: fixed canvas sizes, block schema, and mockup behavior rules
+- `references/pattern-benchmarks.md`: stable benchmark patterns to cite when explaining the options
+
+### assets/
+- `assets/mockup-template/`: reusable web mockup viewer driven by `mockup-data.js`
+- `assets/mockup-template-mobile-app/`: mobile-first review shell and phone-frame stage
+- `assets/mockup-template-desktop-app/`: desktop-app review shell and workstation-frame stage

--- a/skills/ui-mockup-visualizer/agents/openai.yaml
+++ b/skills/ui-mockup-visualizer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "UI Mockup Visualizer"
+  short_description: "Show 3 UI directions as HTML wireframes"
+  default_prompt: "Use $ui-mockup-visualizer to turn this UI/UX request into Option A, Option B, and Option C HTML wireframes with one recommended direction."

--- a/skills/ui-mockup-visualizer/assets/mockup-template-desktop-app/app.js
+++ b/skills/ui-mockup-visualizer/assets/mockup-template-desktop-app/app.js
@@ -1,0 +1,177 @@
+(function () {
+  const data = window.mockupData || {};
+  const options = Array.isArray(data.options) ? data.options : [];
+  if (!options.length) {
+    document.getElementById("app").textContent = "No mockup data found.";
+    return;
+  }
+
+  const state = {
+    selectedId:
+      (location.hash || "").replace("#", "").toUpperCase() ||
+      (options.find((option) => option.recommended) || options[0]).id,
+  };
+
+  function byId(id) {
+    return options.find((option) => option.id === id) || options[0];
+  }
+
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (typeof text === "string") node.textContent = text;
+    return node;
+  }
+
+  function render() {
+    const app = document.getElementById("app");
+    app.innerHTML = "";
+
+    const selected = byId(state.selectedId);
+    location.hash = selected.id;
+
+    const page = el("div", "page");
+    page.dataset.platform = data.platform || selected.canvas.device || "web-desktop";
+    page.appendChild(renderRail(selected));
+    page.appendChild(renderStage(selected));
+    app.appendChild(page);
+  }
+
+  function renderRail(selected) {
+    const rail = el("aside", "rail");
+    rail.appendChild(el("p", "eyebrow", "Visual Review"));
+    rail.appendChild(el("h1", "title", data.question || "UI Mockup"));
+    rail.appendChild(
+      el(
+        "p",
+        "subtitle",
+        "Use the options to confirm the structure quickly. The mockup is fixed-canvas on purpose so the layout stays exact."
+      )
+    );
+
+    if (Array.isArray(data.notes) && data.notes.length) {
+      const noteCard = el("section", "detail-card");
+      noteCard.appendChild(el("h2", "detail-title", "Working Notes"));
+      const list = el("ul", "note-list");
+      data.notes.forEach((note) => list.appendChild(el("li", "", note)));
+      noteCard.appendChild(list);
+      rail.appendChild(noteCard);
+    }
+
+    const optionsWrap = el("section", "options");
+    options.forEach((option) => {
+      const card = el("button", "option-card" + (option.id === selected.id ? " active" : ""));
+      card.type = "button";
+      card.addEventListener("click", () => {
+        state.selectedId = option.id;
+        render();
+      });
+
+      const head = el("div", "option-head");
+      head.appendChild(el("div", "option-name", option.title || `Option ${option.id}`));
+      if (option.recommended) {
+        head.appendChild(el("span", "badge badge-recommended", "Recommended"));
+      }
+      card.appendChild(head);
+      card.appendChild(el("p", "option-summary", option.summary || ""));
+      optionsWrap.appendChild(card);
+    });
+    rail.appendChild(optionsWrap);
+
+    const reply = el("div", "reply-box");
+    reply.innerHTML =
+      "<strong>Reply shortcuts</strong><br />Option A<br />Option A + C<br />None, I want ...";
+    rail.appendChild(reply);
+
+    return rail;
+  }
+
+  function renderStage(option) {
+    const stageShell = el("main", "stage-shell");
+
+    const header = el("section", "stage-header");
+    const meta = el("div", "stage-meta");
+    meta.appendChild(el("p", "eyebrow", `Selected ${option.title}`));
+    meta.appendChild(el("h2", "stage-title", option.summary || ""));
+    meta.appendChild(
+      el(
+        "p",
+        "stage-copy",
+        option.recommended
+          ? "This is the currently recommended direction. Use it as the default unless the user clearly prefers another tradeoff."
+          : "This is a valid alternative. Compare it against the recommended option based on the workflow cost."
+      )
+    );
+
+    const tags = el("div", "stage-tags");
+    tags.appendChild(el("span", "tag", data.platform || option.canvas.device || "web-desktop"));
+    (option.benchmarks || []).forEach((item) => tags.appendChild(el("span", "tag", item)));
+    meta.appendChild(tags);
+    header.appendChild(meta);
+    stageShell.appendChild(header);
+
+    const body = el("section", "stage-body");
+    body.appendChild(renderCanvasPane(option));
+    body.appendChild(renderDetailPane(option));
+    stageShell.appendChild(body);
+    return stageShell;
+  }
+
+  function renderCanvasPane(option) {
+    const pane = el("div", "canvas-pane");
+    const shell = el("div", "canvas-shell");
+    shell.dataset.device = option.canvas.device;
+
+    const canvas = el("div", "canvas");
+    canvas.dataset.device = option.canvas.device;
+    canvas.style.width = `${option.canvas.width}px`;
+    canvas.style.height = `${option.canvas.height}px`;
+
+    (option.blocks || []).forEach((block) => {
+      const node = el("div", `block tone-${block.tone || "default"}`);
+      node.style.left = `${block.x}px`;
+      node.style.top = `${block.y}px`;
+      node.style.width = `${block.w}px`;
+      node.style.height = `${block.h}px`;
+
+      node.appendChild(el("div", "block-label", block.label || ""));
+      node.appendChild(el("div", "block-kind", block.kind || "block"));
+      canvas.appendChild(node);
+    });
+
+    shell.appendChild(canvas);
+    pane.appendChild(shell);
+    return pane;
+  }
+
+  function renderDetailPane(option) {
+    const pane = el("aside", "detail-pane");
+
+    const rationaleCard = el("section", "detail-card");
+    rationaleCard.appendChild(el("h3", "detail-title", "Rationale"));
+    const rationale = el("ul", "rationale-list");
+    (option.rationale || []).forEach((item) => rationale.appendChild(el("li", "", item)));
+    rationaleCard.appendChild(rationale);
+    pane.appendChild(rationaleCard);
+
+    const benchmarkCard = el("section", "detail-card");
+    benchmarkCard.appendChild(el("h3", "detail-title", "Benchmarks"));
+    const benchmarks = el("ul", "benchmark-list");
+    (option.benchmarks || []).forEach((item) => benchmarks.appendChild(el("li", "", item)));
+    benchmarkCard.appendChild(benchmarks);
+    pane.appendChild(benchmarkCard);
+
+    const canvasCard = el("section", "detail-card");
+    canvasCard.appendChild(el("h3", "detail-title", "Canvas"));
+    const canvasList = el("ul", "benchmark-list");
+    canvasList.appendChild(
+      el("li", "", `${option.canvas.device} ${option.canvas.width}x${option.canvas.height}`)
+    );
+    canvasCard.appendChild(canvasList);
+    pane.appendChild(canvasCard);
+
+    return pane;
+  }
+
+  render();
+})();

--- a/skills/ui-mockup-visualizer/assets/mockup-template-desktop-app/index.html
+++ b/skills/ui-mockup-visualizer/assets/mockup-template-desktop-app/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UI Mockup Visualizer</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="./mockup-data.js"></script>
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/skills/ui-mockup-visualizer/assets/mockup-template-desktop-app/mockup-data.js
+++ b/skills/ui-mockup-visualizer/assets/mockup-template-desktop-app/mockup-data.js
@@ -1,0 +1,7 @@
+// This starter file is overwritten by init_mockup_workspace.py.
+window.mockupData = {
+  question: "UI mockup question",
+  platform: "web-desktop",
+  notes: ["Run init_mockup_workspace.py to generate a proper starter file."],
+  options: [],
+};

--- a/skills/ui-mockup-visualizer/assets/mockup-template-desktop-app/styles.css
+++ b/skills/ui-mockup-visualizer/assets/mockup-template-desktop-app/styles.css
@@ -1,0 +1,309 @@
+:root {
+  --bg: #12151b;
+  --bg-strong: #1a1f27;
+  --surface: rgba(25, 30, 38, 0.92);
+  --surface-strong: #232934;
+  --ink: #f4f7fb;
+  --muted: #aab4c3;
+  --line: rgba(255, 255, 255, 0.08);
+  --line-strong: rgba(255, 255, 255, 0.16);
+  --accent: #4fb59f;
+  --accent-soft: rgba(79, 181, 159, 0.16);
+  --focus-fill: rgba(79, 181, 159, 0.12);
+  --canvas-bg: #0f141a;
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --shadow: 0 24px 72px rgba(0, 0, 0, 0.32);
+  --font: "SF Pro Display", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  font-family: var(--font);
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top right, rgba(79, 181, 159, 0.12), transparent 28%),
+    radial-gradient(circle at bottom left, rgba(56, 189, 248, 0.08), transparent 22%),
+    linear-gradient(180deg, var(--bg), var(--bg-strong));
+}
+
+body {
+  min-width: 1280px;
+}
+
+.page {
+  display: grid;
+  grid-template-columns: 300px minmax(0, 1fr);
+  min-height: 100vh;
+  gap: 20px;
+  padding: 20px;
+}
+
+.rail,
+.stage-shell {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+}
+
+.rail {
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.title,
+.stage-title {
+  margin: 0;
+  line-height: 1.12;
+}
+
+.title {
+  font-size: 28px;
+}
+
+.stage-title {
+  font-size: 24px;
+}
+
+.subtitle,
+.stage-copy,
+.note-list,
+.rationale-list,
+.benchmark-list {
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.56;
+}
+
+.subtitle,
+.stage-copy {
+  margin: 8px 0 0;
+}
+
+.note-list,
+.rationale-list,
+.benchmark-list {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.option-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.03);
+  padding: 15px;
+  cursor: pointer;
+  color: var(--ink);
+  transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.option-card:hover {
+  transform: translateY(-1px);
+  border-color: var(--line-strong);
+}
+
+.option-card.active {
+  border-color: rgba(79, 181, 159, 0.44);
+  background: rgba(79, 181, 159, 0.08);
+}
+
+.option-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.option-name {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.badge {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.badge-recommended {
+  background: var(--accent-soft);
+  color: #8ae3cf;
+}
+
+.option-summary {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.stage-shell {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: calc(100vh - 40px);
+  overflow: hidden;
+}
+
+.stage-header {
+  display: flex;
+  padding: 22px 24px 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.stage-meta {
+  display: grid;
+  gap: 12px;
+}
+
+.stage-tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tag {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 7px 11px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.stage-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  min-height: 0;
+}
+
+.canvas-pane {
+  padding: 24px;
+  overflow: auto;
+  border-right: 1px solid var(--line);
+}
+
+.canvas-shell {
+  display: inline-block;
+  padding: 18px;
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02)),
+    #1a2028;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.canvas {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(0deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+    var(--canvas-bg);
+  background-size: 24px 24px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.block {
+  position: absolute;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.06);
+  color: #d6deea;
+}
+
+.block.tone-muted {
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(214, 222, 234, 0.78);
+}
+
+.block.tone-accent {
+  background: var(--focus-fill);
+  border-color: rgba(79, 181, 159, 0.38);
+  box-shadow: inset 0 0 0 1px rgba(79, 181, 159, 0.05);
+}
+
+.block.tone-strong {
+  background: rgba(79, 181, 159, 0.9);
+  border-color: rgba(79, 181, 159, 1);
+  color: #08130f;
+}
+
+.block-kind {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(214, 222, 234, 0.5);
+}
+
+.block-label {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.35;
+  max-width: 84%;
+}
+
+.detail-pane {
+  padding: 22px;
+  overflow: auto;
+  display: grid;
+  gap: 18px;
+  align-content: start;
+}
+
+.detail-card {
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--line);
+}
+
+.detail-title {
+  margin: 0 0 10px;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.reply-box {
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(79, 181, 159, 0.34);
+  padding: 15px;
+  background: rgba(79, 181, 159, 0.08);
+  color: #9ce7d6;
+  font-size: 14px;
+  line-height: 1.55;
+}

--- a/skills/ui-mockup-visualizer/assets/mockup-template-mobile-app/app.js
+++ b/skills/ui-mockup-visualizer/assets/mockup-template-mobile-app/app.js
@@ -1,0 +1,177 @@
+(function () {
+  const data = window.mockupData || {};
+  const options = Array.isArray(data.options) ? data.options : [];
+  if (!options.length) {
+    document.getElementById("app").textContent = "No mockup data found.";
+    return;
+  }
+
+  const state = {
+    selectedId:
+      (location.hash || "").replace("#", "").toUpperCase() ||
+      (options.find((option) => option.recommended) || options[0]).id,
+  };
+
+  function byId(id) {
+    return options.find((option) => option.id === id) || options[0];
+  }
+
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (typeof text === "string") node.textContent = text;
+    return node;
+  }
+
+  function render() {
+    const app = document.getElementById("app");
+    app.innerHTML = "";
+
+    const selected = byId(state.selectedId);
+    location.hash = selected.id;
+
+    const page = el("div", "page");
+    page.dataset.platform = data.platform || selected.canvas.device || "web-desktop";
+    page.appendChild(renderRail(selected));
+    page.appendChild(renderStage(selected));
+    app.appendChild(page);
+  }
+
+  function renderRail(selected) {
+    const rail = el("aside", "rail");
+    rail.appendChild(el("p", "eyebrow", "Visual Review"));
+    rail.appendChild(el("h1", "title", data.question || "UI Mockup"));
+    rail.appendChild(
+      el(
+        "p",
+        "subtitle",
+        "Use the options to confirm the structure quickly. The mockup is fixed-canvas on purpose so the layout stays exact."
+      )
+    );
+
+    if (Array.isArray(data.notes) && data.notes.length) {
+      const noteCard = el("section", "detail-card");
+      noteCard.appendChild(el("h2", "detail-title", "Working Notes"));
+      const list = el("ul", "note-list");
+      data.notes.forEach((note) => list.appendChild(el("li", "", note)));
+      noteCard.appendChild(list);
+      rail.appendChild(noteCard);
+    }
+
+    const optionsWrap = el("section", "options");
+    options.forEach((option) => {
+      const card = el("button", "option-card" + (option.id === selected.id ? " active" : ""));
+      card.type = "button";
+      card.addEventListener("click", () => {
+        state.selectedId = option.id;
+        render();
+      });
+
+      const head = el("div", "option-head");
+      head.appendChild(el("div", "option-name", option.title || `Option ${option.id}`));
+      if (option.recommended) {
+        head.appendChild(el("span", "badge badge-recommended", "Recommended"));
+      }
+      card.appendChild(head);
+      card.appendChild(el("p", "option-summary", option.summary || ""));
+      optionsWrap.appendChild(card);
+    });
+    rail.appendChild(optionsWrap);
+
+    const reply = el("div", "reply-box");
+    reply.innerHTML =
+      "<strong>Reply shortcuts</strong><br />Option A<br />Option A + C<br />None, I want ...";
+    rail.appendChild(reply);
+
+    return rail;
+  }
+
+  function renderStage(option) {
+    const stageShell = el("main", "stage-shell");
+
+    const header = el("section", "stage-header");
+    const meta = el("div", "stage-meta");
+    meta.appendChild(el("p", "eyebrow", `Selected ${option.title}`));
+    meta.appendChild(el("h2", "stage-title", option.summary || ""));
+    meta.appendChild(
+      el(
+        "p",
+        "stage-copy",
+        option.recommended
+          ? "This is the currently recommended direction. Use it as the default unless the user clearly prefers another tradeoff."
+          : "This is a valid alternative. Compare it against the recommended option based on the workflow cost."
+      )
+    );
+
+    const tags = el("div", "stage-tags");
+    tags.appendChild(el("span", "tag", data.platform || option.canvas.device || "web-desktop"));
+    (option.benchmarks || []).forEach((item) => tags.appendChild(el("span", "tag", item)));
+    meta.appendChild(tags);
+    header.appendChild(meta);
+    stageShell.appendChild(header);
+
+    const body = el("section", "stage-body");
+    body.appendChild(renderCanvasPane(option));
+    body.appendChild(renderDetailPane(option));
+    stageShell.appendChild(body);
+    return stageShell;
+  }
+
+  function renderCanvasPane(option) {
+    const pane = el("div", "canvas-pane");
+    const shell = el("div", "canvas-shell");
+    shell.dataset.device = option.canvas.device;
+
+    const canvas = el("div", "canvas");
+    canvas.dataset.device = option.canvas.device;
+    canvas.style.width = `${option.canvas.width}px`;
+    canvas.style.height = `${option.canvas.height}px`;
+
+    (option.blocks || []).forEach((block) => {
+      const node = el("div", `block tone-${block.tone || "default"}`);
+      node.style.left = `${block.x}px`;
+      node.style.top = `${block.y}px`;
+      node.style.width = `${block.w}px`;
+      node.style.height = `${block.h}px`;
+
+      node.appendChild(el("div", "block-label", block.label || ""));
+      node.appendChild(el("div", "block-kind", block.kind || "block"));
+      canvas.appendChild(node);
+    });
+
+    shell.appendChild(canvas);
+    pane.appendChild(shell);
+    return pane;
+  }
+
+  function renderDetailPane(option) {
+    const pane = el("aside", "detail-pane");
+
+    const rationaleCard = el("section", "detail-card");
+    rationaleCard.appendChild(el("h3", "detail-title", "Rationale"));
+    const rationale = el("ul", "rationale-list");
+    (option.rationale || []).forEach((item) => rationale.appendChild(el("li", "", item)));
+    rationaleCard.appendChild(rationale);
+    pane.appendChild(rationaleCard);
+
+    const benchmarkCard = el("section", "detail-card");
+    benchmarkCard.appendChild(el("h3", "detail-title", "Benchmarks"));
+    const benchmarks = el("ul", "benchmark-list");
+    (option.benchmarks || []).forEach((item) => benchmarks.appendChild(el("li", "", item)));
+    benchmarkCard.appendChild(benchmarks);
+    pane.appendChild(benchmarkCard);
+
+    const canvasCard = el("section", "detail-card");
+    canvasCard.appendChild(el("h3", "detail-title", "Canvas"));
+    const canvasList = el("ul", "benchmark-list");
+    canvasList.appendChild(
+      el("li", "", `${option.canvas.device} ${option.canvas.width}x${option.canvas.height}`)
+    );
+    canvasCard.appendChild(canvasList);
+    pane.appendChild(canvasCard);
+
+    return pane;
+  }
+
+  render();
+})();

--- a/skills/ui-mockup-visualizer/assets/mockup-template-mobile-app/index.html
+++ b/skills/ui-mockup-visualizer/assets/mockup-template-mobile-app/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UI Mockup Visualizer</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="./mockup-data.js"></script>
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/skills/ui-mockup-visualizer/assets/mockup-template-mobile-app/mockup-data.js
+++ b/skills/ui-mockup-visualizer/assets/mockup-template-mobile-app/mockup-data.js
@@ -1,0 +1,7 @@
+// This starter file is overwritten by init_mockup_workspace.py.
+window.mockupData = {
+  question: "UI mockup question",
+  platform: "web-desktop",
+  notes: ["Run init_mockup_workspace.py to generate a proper starter file."],
+  options: [],
+};

--- a/skills/ui-mockup-visualizer/assets/mockup-template-mobile-app/styles.css
+++ b/skills/ui-mockup-visualizer/assets/mockup-template-mobile-app/styles.css
@@ -1,0 +1,313 @@
+:root {
+  --bg: #eef1f7;
+  --bg-strong: #dde5f1;
+  --surface: rgba(255, 255, 255, 0.82);
+  --surface-strong: #ffffff;
+  --ink: #111827;
+  --muted: #667085;
+  --line: rgba(15, 23, 42, 0.1);
+  --line-strong: rgba(15, 23, 42, 0.18);
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.12);
+  --focus-fill: #eaf2ff;
+  --phone-shell: #0f172a;
+  --radius-lg: 26px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --shadow: 0 22px 60px rgba(30, 41, 59, 0.16);
+  --font: "SF Pro Display", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  font-family: var(--font);
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top left, rgba(37, 99, 235, 0.14), transparent 34%),
+    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.12), transparent 26%),
+    linear-gradient(180deg, var(--bg), var(--bg-strong));
+}
+
+body {
+  min-width: 1180px;
+}
+
+.page {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  min-height: 100vh;
+  gap: 22px;
+  padding: 22px;
+}
+
+.rail,
+.stage-shell {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow);
+}
+
+.rail {
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.title,
+.stage-title {
+  margin: 0;
+  line-height: 1.14;
+}
+
+.title {
+  font-size: 28px;
+}
+
+.stage-title {
+  font-size: 24px;
+}
+
+.subtitle,
+.stage-copy,
+.note-list,
+.rationale-list,
+.benchmark-list {
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.subtitle,
+.stage-copy {
+  margin: 8px 0 0;
+}
+
+.note-list,
+.rationale-list,
+.benchmark-list {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.option-card,
+.detail-card,
+.reply-box {
+  border-radius: var(--radius-md);
+}
+
+.option-card {
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.68);
+  padding: 15px;
+  cursor: pointer;
+  transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.option-card:hover {
+  transform: translateY(-1px);
+  border-color: var(--line-strong);
+}
+
+.option-card.active {
+  border-color: rgba(37, 99, 235, 0.46);
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.option-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.option-name {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.badge {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.badge-recommended {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.option-summary {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.stage-shell {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: calc(100vh - 44px);
+  overflow: hidden;
+}
+
+.stage-header {
+  display: flex;
+  padding: 22px 24px 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.stage-meta {
+  display: grid;
+  gap: 12px;
+}
+
+.stage-tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tag {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.76);
+  padding: 7px 11px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.stage-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  min-height: 0;
+}
+
+.canvas-pane {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 26px;
+  overflow: auto;
+  border-right: 1px solid var(--line);
+}
+
+.canvas-shell {
+  display: inline-block;
+  border-radius: 42px;
+  padding: 14px;
+  background: linear-gradient(180deg, #172033, #0f172a);
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.24);
+}
+
+.canvas {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(0deg, rgba(15, 23, 42, 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(15, 23, 42, 0.03) 1px, transparent 1px),
+    #fbfcff;
+  background-size: 24px 24px;
+  border-radius: 30px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+}
+
+.block {
+  position: absolute;
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: rgba(255, 255, 255, 0.82);
+  color: #334155;
+}
+
+.block.tone-muted {
+  background: rgba(226, 232, 240, 0.62);
+  color: rgba(51, 65, 85, 0.84);
+}
+
+.block.tone-accent {
+  background: var(--focus-fill);
+  border-color: rgba(37, 99, 235, 0.36);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.06);
+}
+
+.block.tone-strong {
+  background: rgba(37, 99, 235, 0.9);
+  border-color: rgba(37, 99, 235, 1);
+  color: white;
+}
+
+.block-kind {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(51, 65, 85, 0.52);
+}
+
+.block-label {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.35;
+  max-width: 84%;
+}
+
+.detail-pane {
+  padding: 22px;
+  overflow: auto;
+  display: grid;
+  gap: 18px;
+  align-content: start;
+}
+
+.detail-card {
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.66);
+  border: 1px solid var(--line);
+}
+
+.detail-title {
+  margin: 0 0 10px;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.reply-box {
+  border: 1px dashed rgba(37, 99, 235, 0.32);
+  padding: 15px;
+  background: rgba(37, 99, 235, 0.08);
+  color: #1d4ed8;
+  font-size: 14px;
+  line-height: 1.55;
+}

--- a/skills/ui-mockup-visualizer/assets/mockup-template/app.js
+++ b/skills/ui-mockup-visualizer/assets/mockup-template/app.js
@@ -1,0 +1,177 @@
+(function () {
+  const data = window.mockupData || {};
+  const options = Array.isArray(data.options) ? data.options : [];
+  if (!options.length) {
+    document.getElementById("app").textContent = "No mockup data found.";
+    return;
+  }
+
+  const state = {
+    selectedId:
+      (location.hash || "").replace("#", "").toUpperCase() ||
+      (options.find((option) => option.recommended) || options[0]).id,
+  };
+
+  function byId(id) {
+    return options.find((option) => option.id === id) || options[0];
+  }
+
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (typeof text === "string") node.textContent = text;
+    return node;
+  }
+
+  function render() {
+    const app = document.getElementById("app");
+    app.innerHTML = "";
+
+    const selected = byId(state.selectedId);
+    location.hash = selected.id;
+
+    const page = el("div", "page");
+    page.dataset.platform = data.platform || selected.canvas.device || "web-desktop";
+    page.appendChild(renderRail(selected));
+    page.appendChild(renderStage(selected));
+    app.appendChild(page);
+  }
+
+  function renderRail(selected) {
+    const rail = el("aside", "rail");
+    rail.appendChild(el("p", "eyebrow", "Visual Review"));
+    rail.appendChild(el("h1", "title", data.question || "UI Mockup"));
+    rail.appendChild(
+      el(
+        "p",
+        "subtitle",
+        "Use the options to confirm the structure quickly. The mockup is fixed-canvas on purpose so the layout stays exact."
+      )
+    );
+
+    if (Array.isArray(data.notes) && data.notes.length) {
+      const noteCard = el("section", "detail-card");
+      noteCard.appendChild(el("h2", "detail-title", "Working Notes"));
+      const list = el("ul", "note-list");
+      data.notes.forEach((note) => list.appendChild(el("li", "", note)));
+      noteCard.appendChild(list);
+      rail.appendChild(noteCard);
+    }
+
+    const optionsWrap = el("section", "options");
+    options.forEach((option) => {
+      const card = el("button", "option-card" + (option.id === selected.id ? " active" : ""));
+      card.type = "button";
+      card.addEventListener("click", () => {
+        state.selectedId = option.id;
+        render();
+      });
+
+      const head = el("div", "option-head");
+      head.appendChild(el("div", "option-name", option.title || `Option ${option.id}`));
+      if (option.recommended) {
+        head.appendChild(el("span", "badge badge-recommended", "Recommended"));
+      }
+      card.appendChild(head);
+      card.appendChild(el("p", "option-summary", option.summary || ""));
+      optionsWrap.appendChild(card);
+    });
+    rail.appendChild(optionsWrap);
+
+    const reply = el("div", "reply-box");
+    reply.innerHTML =
+      "<strong>Reply shortcuts</strong><br />Option A<br />Option A + C<br />None, I want ...";
+    rail.appendChild(reply);
+
+    return rail;
+  }
+
+  function renderStage(option) {
+    const stageShell = el("main", "stage-shell");
+
+    const header = el("section", "stage-header");
+    const meta = el("div", "stage-meta");
+    meta.appendChild(el("p", "eyebrow", `Selected ${option.title}`));
+    meta.appendChild(el("h2", "stage-title", option.summary || ""));
+    meta.appendChild(
+      el(
+        "p",
+        "stage-copy",
+        option.recommended
+          ? "This is the currently recommended direction. Use it as the default unless the user clearly prefers another tradeoff."
+          : "This is a valid alternative. Compare it against the recommended option based on the workflow cost."
+      )
+    );
+
+    const tags = el("div", "stage-tags");
+    tags.appendChild(el("span", "tag", data.platform || option.canvas.device || "web-desktop"));
+    (option.benchmarks || []).forEach((item) => tags.appendChild(el("span", "tag", item)));
+    meta.appendChild(tags);
+    header.appendChild(meta);
+    stageShell.appendChild(header);
+
+    const body = el("section", "stage-body");
+    body.appendChild(renderCanvasPane(option));
+    body.appendChild(renderDetailPane(option));
+    stageShell.appendChild(body);
+    return stageShell;
+  }
+
+  function renderCanvasPane(option) {
+    const pane = el("div", "canvas-pane");
+    const shell = el("div", "canvas-shell");
+    shell.dataset.device = option.canvas.device;
+
+    const canvas = el("div", "canvas");
+    canvas.dataset.device = option.canvas.device;
+    canvas.style.width = `${option.canvas.width}px`;
+    canvas.style.height = `${option.canvas.height}px`;
+
+    (option.blocks || []).forEach((block) => {
+      const node = el("div", `block tone-${block.tone || "default"}`);
+      node.style.left = `${block.x}px`;
+      node.style.top = `${block.y}px`;
+      node.style.width = `${block.w}px`;
+      node.style.height = `${block.h}px`;
+
+      node.appendChild(el("div", "block-label", block.label || ""));
+      node.appendChild(el("div", "block-kind", block.kind || "block"));
+      canvas.appendChild(node);
+    });
+
+    shell.appendChild(canvas);
+    pane.appendChild(shell);
+    return pane;
+  }
+
+  function renderDetailPane(option) {
+    const pane = el("aside", "detail-pane");
+
+    const rationaleCard = el("section", "detail-card");
+    rationaleCard.appendChild(el("h3", "detail-title", "Rationale"));
+    const rationale = el("ul", "rationale-list");
+    (option.rationale || []).forEach((item) => rationale.appendChild(el("li", "", item)));
+    rationaleCard.appendChild(rationale);
+    pane.appendChild(rationaleCard);
+
+    const benchmarkCard = el("section", "detail-card");
+    benchmarkCard.appendChild(el("h3", "detail-title", "Benchmarks"));
+    const benchmarks = el("ul", "benchmark-list");
+    (option.benchmarks || []).forEach((item) => benchmarks.appendChild(el("li", "", item)));
+    benchmarkCard.appendChild(benchmarks);
+    pane.appendChild(benchmarkCard);
+
+    const canvasCard = el("section", "detail-card");
+    canvasCard.appendChild(el("h3", "detail-title", "Canvas"));
+    const canvasList = el("ul", "benchmark-list");
+    canvasList.appendChild(
+      el("li", "", `${option.canvas.device} ${option.canvas.width}x${option.canvas.height}`)
+    );
+    canvasCard.appendChild(canvasList);
+    pane.appendChild(canvasCard);
+
+    return pane;
+  }
+
+  render();
+})();

--- a/skills/ui-mockup-visualizer/assets/mockup-template/index.html
+++ b/skills/ui-mockup-visualizer/assets/mockup-template/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UI Mockup Visualizer</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="./mockup-data.js"></script>
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/skills/ui-mockup-visualizer/assets/mockup-template/mockup-data.js
+++ b/skills/ui-mockup-visualizer/assets/mockup-template/mockup-data.js
@@ -1,0 +1,7 @@
+// This starter file is overwritten by init_mockup_workspace.py.
+window.mockupData = {
+  question: "UI mockup question",
+  platform: "web-desktop",
+  notes: ["Run init_mockup_workspace.py to generate a proper starter file."],
+  options: [],
+};

--- a/skills/ui-mockup-visualizer/assets/mockup-template/styles.css
+++ b/skills/ui-mockup-visualizer/assets/mockup-template/styles.css
@@ -1,0 +1,326 @@
+:root {
+  --bg: #f4f1eb;
+  --surface: rgba(255, 255, 255, 0.84);
+  --surface-strong: #ffffff;
+  --ink: #111111;
+  --muted: #6f675f;
+  --line: rgba(38, 28, 20, 0.14);
+  --line-strong: rgba(38, 28, 20, 0.24);
+  --accent: #d06c47;
+  --accent-soft: rgba(208, 108, 71, 0.14);
+  --focus-fill: #f7eadf;
+  --radius-lg: 26px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --shadow: 0 20px 60px rgba(56, 34, 22, 0.12);
+  --font: "SF Pro Display", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  font-family: var(--font);
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top left, rgba(208, 108, 71, 0.16), transparent 32%),
+    radial-gradient(circle at bottom right, rgba(44, 120, 153, 0.12), transparent 28%),
+    var(--bg);
+}
+
+body {
+  min-width: 1240px;
+}
+
+.page {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  min-height: 100vh;
+  gap: 24px;
+  padding: 24px;
+}
+
+.rail,
+.stage-shell {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow);
+}
+
+.rail {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.title {
+  margin: 0;
+  font-size: 28px;
+  line-height: 1.15;
+}
+
+.subtitle {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.note-list,
+.rationale-list,
+.benchmark-list {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.option-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.6);
+  padding: 16px;
+  cursor: pointer;
+  transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.option-card:hover {
+  transform: translateY(-1px);
+  border-color: var(--line-strong);
+}
+
+.option-card.active {
+  border-color: rgba(208, 108, 71, 0.5);
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.option-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.option-name {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.badge-recommended {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.option-summary {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.stage-shell {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: calc(100vh - 48px);
+  overflow: hidden;
+}
+
+.stage-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 24px 28px 20px;
+  border-bottom: 1px solid var(--line);
+}
+
+.stage-meta {
+  display: grid;
+  gap: 14px;
+}
+
+.stage-title {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.15;
+}
+
+.stage-copy {
+  margin: 0;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.6;
+  max-width: 760px;
+}
+
+.stage-tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tag {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 7px 11px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.stage-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  min-height: 0;
+}
+
+.canvas-pane {
+  padding: 28px;
+  overflow: auto;
+  border-right: 1px solid var(--line);
+}
+
+.canvas-shell {
+  display: inline-block;
+  border-radius: 28px;
+  padding: 18px;
+  border: 1px solid rgba(38, 28, 20, 0.08);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(247, 243, 238, 0.9));
+}
+
+.canvas-shell[data-device="mobile-app"] {
+  border-radius: 38px;
+}
+
+.canvas-shell[data-device="desktop-app"] {
+  border-radius: 22px;
+}
+
+.canvas {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(0deg, rgba(17, 17, 17, 0.02) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(17, 17, 17, 0.02) 1px, transparent 1px),
+    #fbfaf8;
+  background-size: 24px 24px;
+  border-radius: 20px;
+  border: 1px solid rgba(38, 28, 20, 0.08);
+}
+
+.canvas[data-device="mobile-app"] {
+  border-radius: 28px;
+}
+
+.block {
+  position: absolute;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(38, 28, 20, 0.14);
+  background: rgba(255, 255, 255, 0.8);
+  color: #3f3832;
+}
+
+.block.tone-muted {
+  background: rgba(236, 232, 226, 0.7);
+  color: rgba(63, 56, 50, 0.78);
+}
+
+.block.tone-accent {
+  background: var(--focus-fill);
+  border-color: rgba(208, 108, 71, 0.42);
+  box-shadow: inset 0 0 0 1px rgba(208, 108, 71, 0.08);
+}
+
+.block.tone-strong {
+  background: rgba(208, 108, 71, 0.9);
+  border-color: rgba(208, 108, 71, 1);
+  color: white;
+}
+
+.block-kind {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(63, 56, 50, 0.5);
+}
+
+.block-label {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.35;
+  max-width: 84%;
+}
+
+.detail-pane {
+  padding: 24px;
+  overflow: auto;
+  display: grid;
+  gap: 20px;
+  align-content: start;
+}
+
+.detail-card {
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.66);
+  border: 1px solid var(--line);
+}
+
+.detail-title {
+  margin: 0 0 10px;
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.reply-box {
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(208, 108, 71, 0.4);
+  padding: 16px;
+  background: rgba(208, 108, 71, 0.08);
+  color: #71412b;
+  font-size: 14px;
+  line-height: 1.55;
+}

--- a/skills/ui-mockup-visualizer/references/mockup-design-system.md
+++ b/skills/ui-mockup-visualizer/references/mockup-design-system.md
@@ -1,0 +1,148 @@
+# Mockup Design System
+
+Use this file to keep the visual output stable across sessions.
+
+## Goal
+
+Show the shape, hierarchy, and placement of the idea as fast as possible. Do not spend effort on production-ready content, microcopy, or responsiveness unless the user explicitly asks for those details.
+
+## Fixed Canvases
+
+Use one fixed canvas per option.
+
+- `web-desktop`: `1440x960`
+- `mobile-app`: `390x844`
+- `desktop-app`: `1366x900`
+
+Keep the canvas fixed. Let the browser scroll if the viewport is smaller.
+
+## Template Variants
+
+Use the platform-matched template:
+- `assets/mockup-template/` for `web-desktop`
+- `assets/mockup-template-mobile-app/` for `mobile-app`
+- `assets/mockup-template-desktop-app/` for `desktop-app`
+
+The template variant should change the review shell and framing, not the approval workflow. All variants still use the same Option A/B/C contract.
+
+## Page Structure
+
+The template already provides:
+- a stable review shell
+- an option rail for `Option A`, `Option B`, `Option C`
+- a recommendation badge
+- a stage that renders one option at a time
+- benchmark notes and rationale
+
+Prefer editing only `mockup-data.js`.
+
+## Option Rules
+
+Every mockup session must include:
+- `Option A`
+- `Option B`
+- `Option C`
+- exactly one `recommended: true`
+
+Design the options so the user can choose one, combine several, or reject all.
+
+Good axes for variation:
+- open vs contained layout
+- persistent vs contextual panel
+- dense vs spacious information grouping
+- inline vs overlay interaction
+- left/right/bottom placement when that placement changes the workflow
+
+## Focus Rules
+
+Only render enough surrounding layout to make the focus area understandable.
+
+Example:
+- If the question is about a right sidebar, render the page shell, the content area, and the sidebar.
+- Do not fill the content area with real tables, charts, or cards unless the sidebar behavior depends on them.
+
+## Visual Language
+
+Use a restrained wireframe look:
+- neutral background
+- muted shell surfaces
+- stronger outline and fill for the focus surface
+- simple labels inside blocks
+- subtle accent for the recommended pattern
+
+Avoid:
+- real brand colors from benchmark products
+- production copy
+- placeholder lorem ipsum paragraphs
+- decorative gradients that distract from structure
+
+## Block Schema
+
+The template expects each option to define:
+
+```js
+{
+  id: "A",
+  title: "Option A",
+  summary: "One-line explanation.",
+  recommended: true,
+  rationale: [
+    "Short point 1",
+    "Short point 2"
+  ],
+  benchmarks: [
+    "Notion peek panel",
+    "Slack thread sidebar"
+  ],
+  canvas: {
+    device: "web-desktop",
+    width: 1440,
+    height: 960
+  },
+  blocks: [
+    { kind: "topbar", label: "Top bar", x: 0, y: 0, w: 1440, h: 72 },
+    { kind: "content", label: "Main content", x: 96, y: 72, w: 1024, h: 888, tone: "muted" },
+    { kind: "focus", label: "Right sidebar", x: 1120, y: 72, w: 320, h: 888, tone: "accent" }
+  ]
+}
+```
+
+Supported block kinds:
+- `topbar`
+- `sidebar`
+- `content`
+- `panel`
+- `focus`
+- `sheet`
+- `modal`
+- `card`
+- `table`
+- `list`
+- `form`
+- `toolbar`
+- `footer`
+
+Supported tones:
+- default
+- muted
+- accent
+- strong
+
+Use `focus` or `tone: "accent"` on the area the user is actually reviewing.
+
+## Copy Rules
+
+Keep copy short:
+- one-line summaries
+- short labels inside blocks
+- 2-3 rationale bullets maximum
+
+This is a review artifact, not final UX writing.
+
+## Approval Flow
+
+After the user approves a direction:
+- preserve the approved screenshot
+- keep the final option label stable in the handoff
+- translate the option into implementation rules
+- stop the preview server when it is no longer needed

--- a/skills/ui-mockup-visualizer/references/pattern-benchmarks.md
+++ b/skills/ui-mockup-visualizer/references/pattern-benchmarks.md
@@ -1,0 +1,64 @@
+# Pattern Benchmarks
+
+Use these as pattern references when explaining why an option is reasonable. Cite the pattern, not the brand identity.
+
+## Right Sidebar / Inspector
+
+- `Notion`:
+  - good reference for contextual peek and side-detail views
+  - use when the panel should feel attached to the selected content
+- `Slack`:
+  - good reference for thread, details, and utility sidebars
+  - use when the panel is secondary but persistent during review
+- `Figma`:
+  - good reference for inspector behavior
+  - use when the panel needs precise controls and property grouping
+
+## Dense Back-Office Pages
+
+- `GitHub`:
+  - good reference for clear hierarchy in dense technical pages
+  - use when a page needs tabs, secondary metadata, and compact structure
+- `Shopify Admin`:
+  - good reference for pragmatic admin composition
+  - use when forms, summaries, and side details must coexist cleanly
+- `Stripe Dashboard`:
+  - good reference for controlled density and financial/admin calmness
+  - use when trust and legibility matter more than visual flair
+
+## Task / Workspace Products
+
+- `Linear`:
+  - good reference for compact lists and focused detail panes
+  - use when speed and clarity matter more than decoration
+- `Notion`:
+  - good reference for modular surfaces and nested work areas
+  - use when the structure needs to feel flexible and composable
+
+## Mobile App Structure
+
+- `Apple Settings`:
+  - good reference for predictable settings and preference hierarchy
+  - use when the user wants clarity and low learning cost
+- `Uber Driver`:
+  - good reference for step-driven task surfaces
+  - use when the flow must keep the next action obvious
+- `Airbnb`:
+  - good reference for filter sheets and progressive disclosure
+  - use when the user needs overlays or bottom-sheet comparison
+
+## Desktop App Structure
+
+- `Slack desktop`:
+  - good reference for app-shell framing and utility side panels
+- `Figma desktop`:
+  - good reference for tool density with a stable canvas center
+- `Notion desktop`:
+  - good reference for hybrid document/workspace shells
+
+## Citation Rules
+
+- Mention at most 3 benchmarks per option.
+- Explain the borrowed pattern in plain language.
+- Do not imply legal endorsement or one-to-one copying.
+- If the user asks for current screenshots, exact dates, or proof that a product still behaves that way, browse first.

--- a/skills/ui-mockup-visualizer/scripts/capture_mockup.py
+++ b/skills/ui-mockup-visualizer/scripts/capture_mockup.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+MAC_BROWSERS = [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+]
+
+
+def find_browser() -> str | None:
+    for candidate in MAC_BROWSERS:
+        if Path(candidate).exists():
+            return candidate
+    for name in ("google-chrome", "chromium", "chromium-browser", "chrome"):
+        path = shutil.which(name)
+        if path:
+            return path
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Capture a mockup URL to an image with a local Chromium browser.")
+    parser.add_argument("--url", required=True, help="URL to capture.")
+    parser.add_argument("--output", required=True, help="Output image path.")
+    parser.add_argument("--width", type=int, default=1600, help="Viewport width.")
+    parser.add_argument("--height", type=int, default=1200, help="Viewport height.")
+    parser.add_argument("--delay", type=int, default=1200, help="Virtual time budget in ms.")
+    args = parser.parse_args()
+
+    browser = find_browser()
+    if not browser:
+        print("No Chrome/Chromium executable found.", file=sys.stderr)
+        print("Install Chrome or use Chrome DevTools MCP / Playwright MCP for screenshot capture.", file=sys.stderr)
+        return 1
+
+    output = Path(args.output).expanduser().resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    command = [
+        browser,
+        "--headless=new",
+        "--disable-gpu",
+        "--hide-scrollbars",
+        f"--window-size={args.width},{args.height}",
+        f"--virtual-time-budget={args.delay}",
+        f"--screenshot={output}",
+        args.url,
+    ]
+
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError:
+        if "--headless=new" in command:
+            command[1] = "--headless"
+            subprocess.run(command, check=True)
+        else:
+            raise
+
+    print(f"Saved screenshot: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ui-mockup-visualizer/scripts/init_mockup_workspace.py
+++ b/skills/ui-mockup-visualizer/scripts/init_mockup_workspace.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+TEMPLATE_DIR = SKILL_DIR / "assets" / "mockup-template"
+
+
+def template_dir_for(platform: str) -> Path:
+    mapping = {
+        "web-desktop": SKILL_DIR / "assets" / "mockup-template",
+        "mobile-app": SKILL_DIR / "assets" / "mockup-template-mobile-app",
+        "desktop-app": SKILL_DIR / "assets" / "mockup-template-desktop-app",
+    }
+    return mapping[platform]
+
+
+def slugify(value: str) -> str:
+    chars = []
+    for ch in value.lower().strip():
+        if ch.isalnum():
+            chars.append(ch)
+        elif chars and chars[-1] != "-":
+            chars.append("-")
+    return "".join(chars).strip("-") or "ui-mockup"
+
+
+def sample_options(platform: str) -> list[dict]:
+    if platform == "mobile-app":
+        width, height = 390, 844
+        return [
+            {
+                "id": "A",
+                "title": "Option A",
+                "summary": "Bottom sheet anchored to the active screen.",
+                "recommended": False,
+                "rationale": [
+                    "Keeps the current task visible behind the overlay.",
+                    "Fast to compare choices without leaving the screen.",
+                ],
+                "benchmarks": ["Airbnb filter sheet", "Uber Driver task confirmation"],
+                "canvas": {"device": platform, "width": width, "height": height},
+                "blocks": [
+                    {"kind": "topbar", "label": "Status + top bar", "x": 0, "y": 0, "w": 390, "h": 88},
+                    {"kind": "content", "label": "Current screen", "x": 0, "y": 88, "w": 390, "h": 756, "tone": "muted"},
+                    {"kind": "sheet", "label": "Bottom sheet", "x": 16, "y": 432, "w": 358, "h": 372, "tone": "accent"},
+                ],
+            },
+            {
+                "id": "B",
+                "title": "Option B",
+                "summary": "Step screen with a single primary decision area.",
+                "recommended": True,
+                "rationale": [
+                    "Best when the user should commit to one next action.",
+                    "Lowest ambiguity for production-style flows.",
+                ],
+                "benchmarks": ["Apple Settings hierarchy", "Uber Driver task screen"],
+                "canvas": {"device": platform, "width": width, "height": height},
+                "blocks": [
+                    {"kind": "topbar", "label": "Title bar", "x": 0, "y": 0, "w": 390, "h": 88},
+                    {"kind": "card", "label": "Step summary", "x": 20, "y": 128, "w": 350, "h": 146},
+                    {"kind": "focus", "label": "Primary action area", "x": 20, "y": 304, "w": 350, "h": 320, "tone": "accent"},
+                    {"kind": "footer", "label": "Sticky CTA", "x": 20, "y": 712, "w": 350, "h": 72, "tone": "strong"},
+                ],
+            },
+            {
+                "id": "C",
+                "title": "Option C",
+                "summary": "Tabbed split between overview and advanced controls.",
+                "recommended": False,
+                "rationale": [
+                    "Useful when novice and advanced needs must coexist.",
+                    "Keeps the primary flow lighter than a full settings screen.",
+                ],
+                "benchmarks": ["Notion mobile side surface", "Apple segmented preferences"],
+                "canvas": {"device": platform, "width": width, "height": height},
+                "blocks": [
+                    {"kind": "topbar", "label": "Title + tabs", "x": 0, "y": 0, "w": 390, "h": 116},
+                    {"kind": "card", "label": "Overview panel", "x": 20, "y": 144, "w": 350, "h": 180},
+                    {"kind": "focus", "label": "Config panel", "x": 20, "y": 348, "w": 350, "h": 332, "tone": "accent"},
+                    {"kind": "footer", "label": "Action row", "x": 20, "y": 716, "w": 350, "h": 68},
+                ],
+            },
+        ]
+
+    if platform == "desktop-app":
+        width, height = 1366, 900
+        return [
+            {
+                "id": "A",
+                "title": "Option A",
+                "summary": "Docked inspector on the right side of the workspace.",
+                "recommended": True,
+                "rationale": [
+                    "Fastest to scan while keeping the main workspace visible.",
+                    "Strong fit for desktop operator and workstation products.",
+                ],
+                "benchmarks": ["Figma inspector", "Slack desktop utilities"],
+                "canvas": {"device": platform, "width": width, "height": height},
+                "blocks": [
+                    {"kind": "topbar", "label": "Window chrome", "x": 0, "y": 0, "w": width, "h": 54},
+                    {"kind": "sidebar", "label": "App rail", "x": 0, "y": 54, "w": 88, "h": 846},
+                    {"kind": "content", "label": "Primary workspace", "x": 88, "y": 54, "w": 958, "h": 846, "tone": "muted"},
+                    {"kind": "focus", "label": "Inspector", "x": 1046, "y": 54, "w": 320, "h": 846, "tone": "accent"},
+                ],
+            },
+            {
+                "id": "B",
+                "title": "Option B",
+                "summary": "Floating utility drawer over the main workspace.",
+                "recommended": False,
+                "rationale": [
+                    "Keeps the workspace wide until the operator needs extra detail.",
+                    "Good when the secondary panel is occasional rather than persistent.",
+                ],
+                "benchmarks": ["Notion peek view", "Slack pop-out detail"],
+                "canvas": {"device": platform, "width": width, "height": height},
+                "blocks": [
+                    {"kind": "topbar", "label": "Window chrome", "x": 0, "y": 0, "w": width, "h": 54},
+                    {"kind": "sidebar", "label": "App rail", "x": 0, "y": 54, "w": 88, "h": 846},
+                    {"kind": "content", "label": "Primary workspace", "x": 88, "y": 54, "w": 1278, "h": 846, "tone": "muted"},
+                    {"kind": "sheet", "label": "Floating drawer", "x": 958, "y": 94, "w": 360, "h": 744, "tone": "accent"},
+                ],
+            },
+            {
+                "id": "C",
+                "title": "Option C",
+                "summary": "Split workspace with inline detail column.",
+                "recommended": False,
+                "rationale": [
+                    "Best when the detail view is part of the main workflow, not a utility.",
+                    "Makes comparison easier than a hidden drawer.",
+                ],
+                "benchmarks": ["Linear split detail", "GitHub list + detail"],
+                "canvas": {"device": platform, "width": width, "height": height},
+                "blocks": [
+                    {"kind": "topbar", "label": "Window chrome", "x": 0, "y": 0, "w": width, "h": 54},
+                    {"kind": "sidebar", "label": "App rail", "x": 0, "y": 54, "w": 88, "h": 846},
+                    {"kind": "list", "label": "Main list", "x": 88, "y": 54, "w": 538, "h": 846, "tone": "muted"},
+                    {"kind": "focus", "label": "Inline detail", "x": 626, "y": 54, "w": 740, "h": 846, "tone": "accent"},
+                ],
+            },
+        ]
+
+    width, height = 1440, 960
+    return [
+        {
+            "id": "A",
+            "title": "Option A",
+            "summary": "Full-height docked right sidebar that stays visible while browsing the page.",
+            "recommended": True,
+            "rationale": [
+                "Best when the sidebar is a persistent review or editing surface.",
+                "The surrounding page remains readable with minimal motion cost.",
+            ],
+            "benchmarks": ["Notion peek panel", "Slack thread sidebar"],
+            "canvas": {"device": "web-desktop", "width": width, "height": height},
+            "blocks": [
+                {"kind": "topbar", "label": "Global header", "x": 0, "y": 0, "w": width, "h": 72},
+                {"kind": "sidebar", "label": "Primary nav", "x": 0, "y": 72, "w": 96, "h": 888},
+                {"kind": "content", "label": "Main content", "x": 96, "y": 72, "w": 1024, "h": 888, "tone": "muted"},
+                {"kind": "focus", "label": "Right sidebar", "x": 1120, "y": 72, "w": 320, "h": 888, "tone": "accent"},
+            ],
+        },
+        {
+            "id": "B",
+            "title": "Option B",
+            "summary": "Floating inspector that opens above the content without permanently shrinking it.",
+            "recommended": False,
+            "rationale": [
+                "Useful when the right-side surface is secondary or optional.",
+                "Preserves maximum space for dense tables or dashboards.",
+            ],
+            "benchmarks": ["Notion side peek", "Shopify contextual drawer"],
+            "canvas": {"device": "web-desktop", "width": width, "height": height},
+            "blocks": [
+                {"kind": "topbar", "label": "Global header", "x": 0, "y": 0, "w": width, "h": 72},
+                {"kind": "sidebar", "label": "Primary nav", "x": 0, "y": 72, "w": 96, "h": 888},
+                {"kind": "content", "label": "Main content", "x": 96, "y": 72, "w": 1344, "h": 888, "tone": "muted"},
+                {"kind": "sheet", "label": "Floating inspector", "x": 1016, "y": 120, "w": 368, "h": 760, "tone": "accent"},
+            ],
+        },
+        {
+            "id": "C",
+            "title": "Option C",
+            "summary": "Inline split layout where the detail surface becomes part of the page body.",
+            "recommended": False,
+            "rationale": [
+                "Strong when the user must compare the detail panel with the content continuously.",
+                "Feels more integrated than a utility sidebar.",
+            ],
+            "benchmarks": ["Linear issue detail", "GitHub split information pages"],
+            "canvas": {"device": "web-desktop", "width": width, "height": height},
+            "blocks": [
+                {"kind": "topbar", "label": "Global header", "x": 0, "y": 0, "w": width, "h": 72},
+                {"kind": "sidebar", "label": "Primary nav", "x": 0, "y": 72, "w": 96, "h": 888},
+                {"kind": "content", "label": "Content column", "x": 96, "y": 72, "w": 784, "h": 888, "tone": "muted"},
+                {"kind": "focus", "label": "Integrated detail column", "x": 880, "y": 72, "w": 560, "h": 888, "tone": "accent"},
+            ],
+        },
+    ]
+
+
+def write_mockup_data(path: Path, title: str, platform: str) -> None:
+    payload = {
+        "question": title,
+        "platform": platform,
+        "notes": [
+            "Replace this starter data with the real layout idea.",
+            "Keep Option A, Option B, and Option C labels stable for user review.",
+        ],
+        "options": sample_options(platform),
+    }
+    lines = [
+        "// Edit this file first. Keep the structure stable so the viewer stays reusable.",
+        "window.mockupData = " + json.dumps(payload, indent=2) + ";",
+        "",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create a mockup workspace from the bundled template.")
+    parser.add_argument("target_dir", help="Directory to create or update.")
+    parser.add_argument("--title", default="UI mockup question", help="Human-readable mockup title.")
+    parser.add_argument(
+        "--platform",
+        choices=["web-desktop", "mobile-app", "desktop-app"],
+        default="web-desktop",
+        help="Mockup platform preset.",
+    )
+    parser.add_argument("--overwrite", action="store_true", help="Replace existing files in the target directory.")
+    args = parser.parse_args()
+
+    target_dir = Path(args.target_dir).expanduser().resolve()
+    if target_dir.exists() and any(target_dir.iterdir()) and not args.overwrite:
+        raise SystemExit(f"Target directory is not empty: {target_dir}\nUse --overwrite to replace it.")
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    template_dir = template_dir_for(args.platform)
+    for source in template_dir.iterdir():
+        destination = target_dir / source.name
+        if source.name == "mockup-data.js":
+            continue
+        if destination.exists() and args.overwrite:
+            if destination.is_dir():
+                shutil.rmtree(destination)
+            else:
+                destination.unlink()
+        if source.is_dir():
+            shutil.copytree(source, destination, dirs_exist_ok=args.overwrite)
+        else:
+            shutil.copy2(source, destination)
+
+    title = args.title.strip() or "UI mockup question"
+    write_mockup_data(target_dir / "mockup-data.js", title, args.platform)
+
+    print(f"Mockup workspace ready: {target_dir}")
+    print(f"Suggested slug: {slugify(title)}")
+    print(f"Template: {template_dir.name}")
+    print("Edit mockup-data.js first, then start the preview server.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ui-mockup-visualizer/scripts/start_mockup_server.py
+++ b/skills/ui-mockup-visualizer/scripts/start_mockup_server.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+STATE_FILE = ".mockup-server.json"
+LOG_FILE = ".mockup-server.log"
+
+
+def find_free_port(host: str, preferred: int) -> int:
+    for port in range(preferred, preferred + 50):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind((host, port))
+            except OSError:
+                continue
+            return port
+    raise RuntimeError("No free port found in the reserved range.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Start a static preview server for a mockup directory.")
+    parser.add_argument("root", help="Mockup directory to serve.")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind address. Default: 127.0.0.1")
+    parser.add_argument("--port", type=int, default=4173, help="Preferred starting port. Default: 4173")
+    args = parser.parse_args()
+
+    root = Path(args.root).expanduser().resolve()
+    if not root.is_dir():
+        raise SystemExit(f"Directory not found: {root}")
+    if not (root / "index.html").exists():
+        raise SystemExit(f"index.html not found in {root}")
+
+    state_path = root / STATE_FILE
+    if state_path.exists():
+        raise SystemExit(f"Server state already exists: {state_path}\nStop it first or delete the file.")
+
+    port = find_free_port(args.host, args.port)
+    log_path = root / LOG_FILE
+    with log_path.open("a", encoding="utf-8") as log_file:
+        process = subprocess.Popen(
+            [sys.executable, "-m", "http.server", str(port), "--bind", args.host],
+            cwd=str(root),
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+
+    url = f"http://{args.host}:{port}"
+    state = {
+        "pid": process.pid,
+        "host": args.host,
+        "port": port,
+        "url": url,
+        "root": str(root),
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+    }
+    state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Serving: {root}")
+    print(f"URL: {url}")
+    print(f"State: {state_path}")
+    print(f"Log: {log_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ui-mockup-visualizer/scripts/stop_mockup_server.py
+++ b/skills/ui-mockup-visualizer/scripts/stop_mockup_server.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+from pathlib import Path
+
+
+STATE_FILE = ".mockup-server.json"
+
+
+def terminate(pid: int) -> None:
+    try:
+        os.killpg(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    except PermissionError:
+        os.kill(pid, signal.SIGTERM)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Stop a mockup preview server created by start_mockup_server.py.")
+    parser.add_argument("root", help="Mockup directory that contains .mockup-server.json")
+    args = parser.parse_args()
+
+    root = Path(args.root).expanduser().resolve()
+    state_path = root / STATE_FILE
+    if not state_path.exists():
+        raise SystemExit(f"State file not found: {state_path}")
+
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    pid = int(state["pid"])
+    terminate(pid)
+    state_path.unlink(missing_ok=True)
+
+    print(f"Stopped server pid {pid}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the `ui-mockup-visualizer` skill with reusable scripts, references, and web/mobile/desktop HTML mockup templates
- add a new `ui-design-skills` plugin group and regenerate the marketplace and README tables
- update contribution docs to include the recommended `author` field in skill metadata

## Validation
- `npm run sync`
- `npm run validate`
- smoke-tested `skills/ui-mockup-visualizer/scripts/init_mockup_workspace.py`
- smoke-tested `skills/ui-mockup-visualizer/scripts/start_mockup_server.py`
- smoke-tested `skills/ui-mockup-visualizer/scripts/capture_mockup.py`
- smoke-tested `skills/ui-mockup-visualizer/scripts/stop_mockup_server.py`
