### PR TITLE
feat: add video production routing skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -51,6 +51,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity"
+    },
+    {
+      "name": "video-production-skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/video-production-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -87,6 +87,25 @@
         "office-web-ui-system"
       ],
       "category": "productivity"
+    },
+    {
+      "name": "video-production-skills",
+      "source": "./plugins/video-production-skills",
+      "description": "Skills for routing video briefs across generation, deterministic composition, supplied-footage editing, and automatic end-to-end production plans.",
+      "version": "1.21.1",
+      "author": {
+        "name": "Ân Vũ",
+        "email": "8651688+thienanblog@users.noreply.github.com"
+      },
+      "homepage": "https://github.com/thienanblog/awesome-ai-agent-skills",
+      "repository": "https://github.com/thienanblog/awesome-ai-agent-skills",
+      "license": "MIT",
+      "keywords": [
+        "claude-code",
+        "agent-skills",
+        "video-router"
+      ],
+      "category": "productivity"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ The matching `plugins/project-development-skills/.claude-plugin/plugin.json`:
 | run-reviewable-subtask-loop  | `./skills/run-reviewable-subtask-loop` | Deliver large changes as right-sized, reviewable, testable slices  |
 | testing-verification         | `./skills/testing-verification`        | Plan, add, repair, and run tests and verification                  |
 | ui-ux-concept-implementation | `./skills/ui-ux-concept-implementation`| Implement UI from selected concepts or reference websites          |
+| video-router                 | `./skills/video-router`                | Route video briefs before production begins                        |
 | vps-docker-traefik-deploy    | `./skills/vps-docker-traefik-deploy`   | Plan and implement secure Docker/Traefik VPS deployments           |
 
 ## GitHub CI Validation

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Skills are self-contained instruction sets that teach AI agents specific workflo
 
 # Install office web UI skill
 /plugin install office-web-ui-skills@awesome-ai-agent-skills
+
+# Install video production routing skill
+/plugin install video-production-skills@awesome-ai-agent-skills
 ```
 
 **Updating the marketplace**
@@ -89,6 +92,7 @@ In the plugin browser:
    - `laravel-app-skills`
    - `devops-skills`
    - `office-web-ui-skills`
+   - `video-production-skills`
 3. Select **Install plugin**.
 4. Start a new thread and ask Codex normally, or type `@` to choose the plugin or one of its bundled skills explicitly.
 
@@ -173,6 +177,7 @@ Use $run-reviewable-subtask-loop to split this migration into right-sized, coher
 | [run-reviewable-subtask-loop](./skills/run-reviewable-subtask-loop) | Deliver a large implementation plan, architecture migration, refactor, or feature roadmap as right-sized, coherent subtasks with focused per-slice local checks, one full final local gate, and explicitly authorized Remote CI. Use only when the user explicitly requests this skill or workflow, or explicitly accepts it after an optional proposal during a user-initiated brainstorming or planning session before coding. Do not use for ordinary coding requests with clear requirements and no prior user-requested brainstorming or discussion. This skill does not authorize subagents; before any spawn, explain the usage impact and obtain explicit user approval for the proposed agent count and scope. |
 | [testing-verification](./skills/testing-verification) | Plan, add, repair, and run tests and verification for software changes. Use when the user asks for tests, coverage, QA, acceptance criteria, regression checks, CI test failures, Playwright or browser verification, UI screenshot comparison, visual regression, or when a code change needs a focused test strategy across frontend, backend, API, or full-stack workflows. |
 | [ui-ux-concept-implementation](./skills/ui-ux-concept-implementation) | Implement frontend UI/UX from user-approved concepts, mockups, screenshots, visual references, or a website the user wants to emulate or clone. Use when Codex must generate and compare UI concepts, recommend a concept as a technical leader, predict the user's likely preference, persist the chosen concept outside commits, recreate a reference site's look and interactions in an existing project, or verify before/after UI with Playwright, Playwright MCP, Chrome DevTools MCP, screenshots, and responsive checks. |
+| [video-router](./skills/video-router) | Use first on any video-production request to choose and lock generation, deterministic composition, supplied-footage editing, or an AUTO end-to-end route before work begins. |
 | [vps-docker-traefik-deploy](./skills/vps-docker-traefik-deploy) | Plan and implement secure production deployments of Docker Compose applications on self-hosted VPS or cloud servers using Docker Engine, Docker Compose, Traefik, private registries, SSH tunnels, least-privilege users, persistent volumes, backups, DNS, and storage growth planning. Use when an AI agent needs to design, review, document, or execute a real deploy for websites, APIs, websockets, workers, databases, and object storage integrations on Ubuntu or Debian style Linux hosts. |
 <!-- SKILLS_TABLE_END -->
 
@@ -187,6 +192,7 @@ Plugins bundle related skills so you can install by domain. The source of truth 
 | [laravel-app-skills](./plugin-groups.json) | Guidelines for building Laravel 11/12 apps across common stacks and tooling. | [laravel-11-12-app-guidelines](./skills/laravel-11-12-app-guidelines) |
 | [devops-skills](./plugin-groups.json) | Skills for Docker-based local development environment configuration. | [docker-local-dev](./skills/docker-local-dev) |
 | [office-web-ui-skills](./plugin-groups.json) | Skills for designing and refactoring admin, internal, and back-office web interfaces. | [office-web-ui-system](./skills/office-web-ui-system) |
+| [video-production-skills](./plugin-groups.json) | Skills for routing video briefs across generation, deterministic composition, supplied-footage editing, and automatic end-to-end production plans. | [video-router](./skills/video-router) |
 <!-- PLUGINS_TABLE_END -->
 
 ## Repository Cleanup

--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -44,6 +44,14 @@
       "skills": [
         "office-web-ui-system"
       ]
+    },
+    {
+      "name": "video-production-skills",
+      "displayName": "Video Production Skills",
+      "description": "Skills for routing video briefs across generation, deterministic composition, supplied-footage editing, and automatic end-to-end production plans.",
+      "skills": [
+        "video-router"
+      ]
     }
   ]
 }

--- a/plugins/video-production-skills/.claude-plugin/plugin.json
+++ b/plugins/video-production-skills/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "video-production-skills",
+  "version": "1.21.1",
+  "description": "Skills for routing video briefs across generation, deterministic composition, supplied-footage editing, and automatic end-to-end production plans.",
+  "author": {
+    "name": "Ân Vũ",
+    "email": "8651688+thienanblog@users.noreply.github.com"
+  },
+  "homepage": "https://github.com/thienanblog/awesome-ai-agent-skills",
+  "repository": "https://github.com/thienanblog/awesome-ai-agent-skills",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "agent-skills",
+    "video-router"
+  ]
+}

--- a/plugins/video-production-skills/.codex-plugin/plugin.json
+++ b/plugins/video-production-skills/.codex-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "video-production-skills",
+  "version": "1.21.1",
+  "description": "Skills for routing video briefs across generation, deterministic composition, supplied-footage editing, and automatic end-to-end production plans.",
+  "homepage": "https://github.com/thienanblog/awesome-ai-agent-skills",
+  "repository": "https://github.com/thienanblog/awesome-ai-agent-skills",
+  "license": "MIT",
+  "keywords": [
+    "codex",
+    "skills",
+    "video-router"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Video Production Skills",
+    "shortDescription": "Skills for routing video briefs across generation, deterministic composition, supplied-footage editing, and automatic end-to-end production plans.",
+    "longDescription": "Skills for routing video briefs across generation, deterministic composition, supplied-footage editing, and automatic end-to-end production plans.",
+    "developerName": "Ân Vũ",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/thienanblog/awesome-ai-agent-skills",
+    "defaultPrompt": [
+      "Use video-router to guide this project task.",
+      "Apply video-production-skills to review this repository."
+    ],
+    "brandColor": "#10A37F"
+  }
+}

--- a/plugins/video-production-skills/skills/video-router/LICENSE
+++ b/plugins/video-production-skills/skills/video-router/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Orkas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/video-production-skills/skills/video-router/SKILL.md
+++ b/plugins/video-production-skills/skills/video-router/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: video-router
+description: "Use first on any video-production request to choose and lock generation, deterministic composition, supplied-footage editing, or an AUTO end-to-end route before work begins."
+---
+
+# Video Router
+
+Knowledge for picking a video production line and locking it before work begins. This skill is read for guidance; it describes **what to decide**, not any tool mechanics.
+
+Run this skill in the main conversation by default. Do not spawn subagents, agent teams, or delegated workers unless the user is warned that delegation can increase usage and explicitly approves the proposed agent count and scope. Ask again before expanding an approved scope.
+
+## When to Use This Skill
+
+- Use before production when a request asks to make, compose, generate, edit, repurpose, or finish a video.
+- Use when a mixed brief needs one explicit primary path or an AUTO end-to-end route.
+- Do not use it to author compositions, generate assets, edit media, or render output; hand those tasks to the relevant production skill after routing.
+
+## Unavailable Production Runtime
+
+If production, rendering, or paid tools are explicitly unavailable, still select the line and return a complete **unexecuted production package** for a clear brief: assumptions, script/narration, timed storyboard/shotlist, exact visible copy and captions, visual/audio direction, rights-safe asset provenance/fallbacks, export target, preview checklist, and final encoding/playback QA. Clearly distinguish planned from produced media and do not withhold the package behind a direction form.
+
+## The Three Capability Axes
+
+A finished video is built from one or more of three orthogonal axes. Decide which dominate, then lock them.
+
+- **Generate (A)** — AI-generated footage/imagery: photoreal shots, b-roll, motion, talking-head. Use when the brief needs real-looking or cinematic visuals.
+- **Compose (B)** — deterministic HTML composition: explainers, kinetic typography, motion graphics, captions / lower-thirds / overlays, data viz, title cards, transitions. Use when the visuals are designed rather than filmed. This is the default for explainer/animation work.
+- **Edit (C)** — intelligent editing of supplied footage: evidence-based selection/cleanup, deterministic cut/join/reframe/captions/audio work, and semantic AI video editing for bounded pixel-level changes.
+
+## Decision Rules
+
+1. Read the brief (topic, aspect ratio, language, duration) and classify the **dominant work object**:
+   - "explain / teach / animate / motion-graphics / kinetic text" → **Compose (B)** primary, optionally Generate (A) for b-roll.
+   - "make footage of / cinematic / a scene of / a character doing" → **Generate (A)** primary, Compose (B) to overlay captions.
+   - "cut / clip / trim / repurpose / make highlights / remove or change something in my video" → **Edit (C)** primary. Keep EDIT as the route even when a billable `operation:"edit"` segment is required.
+2. Most explainer/animation requests are **Compose-primary**: typographic and motion-graphic scenes assembled as an HTML composition, with AI imagery only where a shot genuinely needs it.
+3. For supplied reference media, classify the requested relationship as `reproduce`, `edit`, or `guide` before choosing execution. Apply the same classification regardless of origin. Images can control content/identity/composition/structure/style; videos can additionally control motion/timing/audio through temporal anchors.
+4. Aspect ratio drives the canvas: 16:9 → 1920×1080, 9:16 → 1080×1920, 1:1 → 1080×1080.
+
+## End-to-End (AUTO) — When the Job Spans Lines
+
+Pick a **single line** when one axis cleanly dominates (just trim a clip; just an explainer; just generate a scene). Route to **AUTO end-to-end** when the deliverable genuinely needs MORE THAN ONE axis woven together — most often the user supplies their own material AND wants finished framing/voice/motion around it:
+
+- "trim my clip, add a title card + captions, and a voiceover" (edit + compose + narration)
+- "my footage in the middle, generate an opener, compose the stats" (edit + generate + compose)
+- "make a finished video from these assets" where the assets alone are not the deliverable.
+
+AUTO does not abandon the axes — it sequences them through one cross-modal plan (`stage-plan` builds the EDL, `stage-assemble` walks it), delegating each segment back to the generate / compose / edit lines. Choosing AUTO is itself the lock: the *primary* still gets named via the plan's `delivery_promise` (source_led / motion_led / compose_led / hybrid).
+
+## Lock the Runtime
+
+- Decide the primary axis at the brief/proposal stage and **state it in the proposal**.
+- Once locked, do not silently switch the primary axis mid-run. If a later step reveals the wrong choice, surface it to the user and re-confirm rather than quietly changing course.
+- Layering is fine and expected (e.g. Compose captions over Generated footage); "locking" governs the **primary** path, not the allowed overlays.
+
+## Examples
+
+### Compose Primary
+
+Request: "Make a 60-second vertical explainer about vector databases with kinetic text and captions."
+
+Route: lock **Compose (B)** primary at 1080×1920. Add Generate (A) only if the approved concept needs original b-roll.
+
+### Edit Primary
+
+Request: "Turn my one-hour interview into three captioned highlight clips."
+
+Route: lock **Edit (C)** primary because supplied footage is the dominant work object. Preserve evidence for selections and cleanup.
+
+### AUTO End-to-End
+
+Request: "Use my product footage, generate a five-second opener, compose the feature stats, and add one voiceover."
+
+Route: lock **AUTO**, name the delivery promise, and plan the edit, generate, compose, and narration segments in one cross-modal EDL.
+
+## Limitations
+
+- This skill chooses and locks a route; it does not provide a renderer, editor, media generator, or production runtime.
+- Stage names such as `stage-plan` and `stage-assemble` refer to the upstream OrkasVideoStudio workflow and may be unavailable unless the user separately installs or supplies a compatible runtime.
+- Generation provider access, costs, licensing, and safety constraints are outside this router; confirm them before a downstream generation stage.
+- Do not claim media was produced when only an unexecuted production package was prepared.
+
+## Boundary / Non-Goals
+
+This skill only routes and locks. Semantic editing is not a silent switch to GENERATE: it remains an EDIT/AUTO job with a signed billable video edit segment and explicit original/preservation boundary.
+
+## Source and License
+
+Adapted from the official OrkasVideoStudio `video-router` skill at commit [`dd4a0f40b2bc6c6b0fe6f2e732c9540ffffefe08`](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/dd4a0f40b2bc6c6b0fe6f2e732c9540ffffefe08/packages/skills/video-router). The upstream source is MIT licensed; the copyright and permission notice are included in this directory's `LICENSE` file.

--- a/skills/video-router/LICENSE
+++ b/skills/video-router/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Orkas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/video-router/SKILL.md
+++ b/skills/video-router/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: video-router
+description: "Use first on any video-production request to choose and lock generation, deterministic composition, supplied-footage editing, or an AUTO end-to-end route before work begins."
+---
+
+# Video Router
+
+Knowledge for picking a video production line and locking it before work begins. This skill is read for guidance; it describes **what to decide**, not any tool mechanics.
+
+Run this skill in the main conversation by default. Do not spawn subagents, agent teams, or delegated workers unless the user is warned that delegation can increase usage and explicitly approves the proposed agent count and scope. Ask again before expanding an approved scope.
+
+## When to Use This Skill
+
+- Use before production when a request asks to make, compose, generate, edit, repurpose, or finish a video.
+- Use when a mixed brief needs one explicit primary path or an AUTO end-to-end route.
+- Do not use it to author compositions, generate assets, edit media, or render output; hand those tasks to the relevant production skill after routing.
+
+## Unavailable Production Runtime
+
+If production, rendering, or paid tools are explicitly unavailable, still select the line and return a complete **unexecuted production package** for a clear brief: assumptions, script/narration, timed storyboard/shotlist, exact visible copy and captions, visual/audio direction, rights-safe asset provenance/fallbacks, export target, preview checklist, and final encoding/playback QA. Clearly distinguish planned from produced media and do not withhold the package behind a direction form.
+
+## The Three Capability Axes
+
+A finished video is built from one or more of three orthogonal axes. Decide which dominate, then lock them.
+
+- **Generate (A)** — AI-generated footage/imagery: photoreal shots, b-roll, motion, talking-head. Use when the brief needs real-looking or cinematic visuals.
+- **Compose (B)** — deterministic HTML composition: explainers, kinetic typography, motion graphics, captions / lower-thirds / overlays, data viz, title cards, transitions. Use when the visuals are designed rather than filmed. This is the default for explainer/animation work.
+- **Edit (C)** — intelligent editing of supplied footage: evidence-based selection/cleanup, deterministic cut/join/reframe/captions/audio work, and semantic AI video editing for bounded pixel-level changes.
+
+## Decision Rules
+
+1. Read the brief (topic, aspect ratio, language, duration) and classify the **dominant work object**:
+   - "explain / teach / animate / motion-graphics / kinetic text" → **Compose (B)** primary, optionally Generate (A) for b-roll.
+   - "make footage of / cinematic / a scene of / a character doing" → **Generate (A)** primary, Compose (B) to overlay captions.
+   - "cut / clip / trim / repurpose / make highlights / remove or change something in my video" → **Edit (C)** primary. Keep EDIT as the route even when a billable `operation:"edit"` segment is required.
+2. Most explainer/animation requests are **Compose-primary**: typographic and motion-graphic scenes assembled as an HTML composition, with AI imagery only where a shot genuinely needs it.
+3. For supplied reference media, classify the requested relationship as `reproduce`, `edit`, or `guide` before choosing execution. Apply the same classification regardless of origin. Images can control content/identity/composition/structure/style; videos can additionally control motion/timing/audio through temporal anchors.
+4. Aspect ratio drives the canvas: 16:9 → 1920×1080, 9:16 → 1080×1920, 1:1 → 1080×1080.
+
+## End-to-End (AUTO) — When the Job Spans Lines
+
+Pick a **single line** when one axis cleanly dominates (just trim a clip; just an explainer; just generate a scene). Route to **AUTO end-to-end** when the deliverable genuinely needs MORE THAN ONE axis woven together — most often the user supplies their own material AND wants finished framing/voice/motion around it:
+
+- "trim my clip, add a title card + captions, and a voiceover" (edit + compose + narration)
+- "my footage in the middle, generate an opener, compose the stats" (edit + generate + compose)
+- "make a finished video from these assets" where the assets alone are not the deliverable.
+
+AUTO does not abandon the axes — it sequences them through one cross-modal plan (`stage-plan` builds the EDL, `stage-assemble` walks it), delegating each segment back to the generate / compose / edit lines. Choosing AUTO is itself the lock: the *primary* still gets named via the plan's `delivery_promise` (source_led / motion_led / compose_led / hybrid).
+
+## Lock the Runtime
+
+- Decide the primary axis at the brief/proposal stage and **state it in the proposal**.
+- Once locked, do not silently switch the primary axis mid-run. If a later step reveals the wrong choice, surface it to the user and re-confirm rather than quietly changing course.
+- Layering is fine and expected (e.g. Compose captions over Generated footage); "locking" governs the **primary** path, not the allowed overlays.
+
+## Examples
+
+### Compose Primary
+
+Request: "Make a 60-second vertical explainer about vector databases with kinetic text and captions."
+
+Route: lock **Compose (B)** primary at 1080×1920. Add Generate (A) only if the approved concept needs original b-roll.
+
+### Edit Primary
+
+Request: "Turn my one-hour interview into three captioned highlight clips."
+
+Route: lock **Edit (C)** primary because supplied footage is the dominant work object. Preserve evidence for selections and cleanup.
+
+### AUTO End-to-End
+
+Request: "Use my product footage, generate a five-second opener, compose the feature stats, and add one voiceover."
+
+Route: lock **AUTO**, name the delivery promise, and plan the edit, generate, compose, and narration segments in one cross-modal EDL.
+
+## Limitations
+
+- This skill chooses and locks a route; it does not provide a renderer, editor, media generator, or production runtime.
+- Stage names such as `stage-plan` and `stage-assemble` refer to the upstream OrkasVideoStudio workflow and may be unavailable unless the user separately installs or supplies a compatible runtime.
+- Generation provider access, costs, licensing, and safety constraints are outside this router; confirm them before a downstream generation stage.
+- Do not claim media was produced when only an unexecuted production package was prepared.
+
+## Boundary / Non-Goals
+
+This skill only routes and locks. Semantic editing is not a silent switch to GENERATE: it remains an EDIT/AUTO job with a signed billable video edit segment and explicit original/preservation boundary.
+
+## Source and License
+
+Adapted from the official OrkasVideoStudio `video-router` skill at commit [`dd4a0f40b2bc6c6b0fe6f2e732c9540ffffefe08`](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/dd4a0f40b2bc6c6b0fe6f2e732c9540ffffefe08/packages/skills/video-router). The upstream source is MIT licensed; the copyright and permission notice are included in this directory's `LICENSE` file.


### PR DESCRIPTION
## Summary

Adds the official OrkasVideoStudio `video-router` skill and assigns it to a new `video-production-skills` plugin bundle.

The skill helps an agent choose and lock one of four routes before production begins: generation, deterministic composition, supplied-footage editing, or an AUTO end-to-end plan. The adaptation is pinned to upstream commit `dd4a0f40b2bc6c6b0fe6f2e732c9540ffffefe08`, retains tool-agnostic instructions, includes clear examples and limitations, and carries the upstream MIT notice.

Generated Claude and Codex marketplaces, plugin manifests, the bundled skill copy, and README tables were produced by the repository's sync command rather than edited directly.

## Checks

- `npm run sync` — passed
- `npm run validate` — passed (14 valid skills)
- `npm run test:agent-context` — passed
- `claude plugin validate .` — passed
- `claude plugin validate ./plugins/video-production-skills` — passed
- `git diff --check` — passed

## Source

- repository: https://github.com/Orkas-AI/Orkas-VideoStudio
- pinned skill: https://github.com/Orkas-AI/Orkas-VideoStudio/tree/dd4a0f40b2bc6c6b0fe6f2e732c9540ffffefe08/packages/skills/video-router
- license: MIT

## Disclosure

I am submitting this contribution on behalf of the Orkas project.
