### PR TITLE
chore: prepare v1.27.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Community-shared skills for AI coding agents",
-    "version": "1.26.0"
+    "version": "1.27.0"
   },
   "plugins": [
     {
       "name": "project-development-skills",
       "source": "./plugins/project-development-skills",
       "description": "A cohesive workflow bundle for project setup, source-of-truth development, reviewable multi-subtask delivery, UI/UX concept implementation, testing, debugging, performance, documentation, design systems, and production deployment planning.",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "author": {
         "name": "Ân Vũ",
         "email": "8651688+thienanblog@users.noreply.github.com"
@@ -35,7 +35,7 @@
       "name": "laravel-app-skills",
       "source": "./plugins/laravel-app-skills",
       "description": "Version-aware guidelines for building and upgrading Laravel 11, 12, and 13 applications across common stacks and tooling.",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "author": {
         "name": "Ân Vũ",
         "email": "8651688+thienanblog@users.noreply.github.com"
@@ -55,7 +55,7 @@
       "name": "devops-skills",
       "source": "./plugins/devops-skills",
       "description": "Skills for Docker-based local development environment configuration.",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "author": {
         "name": "Ân Vũ",
         "email": "8651688+thienanblog@users.noreply.github.com"
@@ -74,7 +74,7 @@
       "name": "office-web-ui-skills",
       "source": "./plugins/office-web-ui-skills",
       "description": "Skills for designing and refactoring admin, internal, and back-office web interfaces.",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "author": {
         "name": "Ân Vũ",
         "email": "8651688+thienanblog@users.noreply.github.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "awesome-ai-agent-skills",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "awesome-ai-agent-skills",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "devDependencies": {
         "yaml": "^2.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-ai-agent-skills",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Community-shared skills for AI coding agents",
   "private": true,
   "type": "module",

--- a/plugins/devops-skills/.claude-plugin/plugin.json
+++ b/plugins/devops-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-skills",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Skills for Docker-based local development environment configuration.",
   "author": {
     "name": "Ân Vũ",

--- a/plugins/devops-skills/.codex-plugin/plugin.json
+++ b/plugins/devops-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-skills",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Skills for Docker-based local development environment configuration.",
   "homepage": "https://github.com/thienanblog/awesome-ai-agent-skills",
   "repository": "https://github.com/thienanblog/awesome-ai-agent-skills",

--- a/plugins/laravel-app-skills/.claude-plugin/plugin.json
+++ b/plugins/laravel-app-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-app-skills",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Version-aware guidelines for building and upgrading Laravel 11, 12, and 13 applications across common stacks and tooling.",
   "author": {
     "name": "Ân Vũ",

--- a/plugins/laravel-app-skills/.codex-plugin/plugin.json
+++ b/plugins/laravel-app-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-app-skills",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Version-aware guidelines for building and upgrading Laravel 11, 12, and 13 applications across common stacks and tooling.",
   "homepage": "https://github.com/thienanblog/awesome-ai-agent-skills",
   "repository": "https://github.com/thienanblog/awesome-ai-agent-skills",

--- a/plugins/office-web-ui-skills/.claude-plugin/plugin.json
+++ b/plugins/office-web-ui-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "office-web-ui-skills",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Skills for designing and refactoring admin, internal, and back-office web interfaces.",
   "author": {
     "name": "Ân Vũ",

--- a/plugins/office-web-ui-skills/.codex-plugin/plugin.json
+++ b/plugins/office-web-ui-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "office-web-ui-skills",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Skills for designing and refactoring admin, internal, and back-office web interfaces.",
   "homepage": "https://github.com/thienanblog/awesome-ai-agent-skills",
   "repository": "https://github.com/thienanblog/awesome-ai-agent-skills",

--- a/plugins/project-development-skills/.claude-plugin/plugin.json
+++ b/plugins/project-development-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-development-skills",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "A cohesive workflow bundle for project setup, source-of-truth development, reviewable multi-subtask delivery, UI/UX concept implementation, testing, debugging, performance, documentation, design systems, and production deployment planning.",
   "author": {
     "name": "Ân Vũ",

--- a/plugins/project-development-skills/.codex-plugin/plugin.json
+++ b/plugins/project-development-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-development-skills",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "A cohesive workflow bundle for project setup, source-of-truth development, reviewable multi-subtask delivery, UI/UX concept implementation, testing, debugging, performance, documentation, design systems, and production deployment planning.",
   "homepage": "https://github.com/thienanblog/awesome-ai-agent-skills",
   "repository": "https://github.com/thienanblog/awesome-ai-agent-skills",


### PR DESCRIPTION
## Summary

- bump the package release source of truth from 1.26.0 to 1.27.0
- regenerate Claude marketplace and all Claude/Codex plugin manifests
- prepare the reviewable subtask workflow changes merged in #39 for distribution

## Release scope

This release adds resumable per-subtask planning, final UI/UX and requirement-fit gates, mode-aware recovery, safe temporary-plan cleanup, and standardized task/subtask/phase terminology. It contains no breaking changes or required migration.

## Validation

- Node 20.20.2 / npm 10.9.9
- npm ci
- npm run validate
- npm run test:agent-context
- npm run test:docker-local-dev
- npm run sync followed by generated-file parity check
- claude plugin validate .
- git diff --check HEAD^ HEAD
